### PR TITLE
Removed loading of slack-source kamelet

### DIFF
--- a/test/slack/slack-source.feature
+++ b/test/slack/slack-source.feature
@@ -5,7 +5,7 @@ Feature: Slack Kamelet
     Given Disable auto removal of Kamelet resources
 
   Scenario: Create Camel-K resources
-    And load Camel-K integration slack-to-log.groovy
+    Given load Camel-K integration slack-to-log.groovy
 
   Scenario: Verify Kamelet source
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"

--- a/test/slack/slack-source.feature
+++ b/test/slack/slack-source.feature
@@ -5,9 +5,7 @@ Feature: Slack Kamelet
     Given Disable auto removal of Kamelet resources
 
   Scenario: Create Camel-K resources
-    When load Kamelet slack-source.kamelet.yaml
     And load Camel-K integration slack-to-log.groovy
-    Then Kamelet slack-source is available
 
   Scenario: Verify Kamelet source
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"

--- a/test/slack/yaks-config.yaml
+++ b/test/slack/yaks-config.yaml
@@ -18,7 +18,6 @@
 config:
   runtime:
     resources:
-      - ../../slack-source.kamelet.yaml
       - slack-to-log.groovy
 pre:
   - script: prepare-secret.sh


### PR DESCRIPTION
The slack-source kamelet which we need to test should be loaded by camel-k operator