### PR TITLE
[ENTESB-15377] Add basic aws sqs test

### DIFF
--- a/test/aws-sqs/README.md
+++ b/test/aws-sqs/README.md
@@ -1,0 +1,68 @@
+# AWS SQS Kamelet test
+
+This test verifies the AWS SQS Kamelet source defined in [aws-sqs-source.kamelet.yaml](aws-sqs-source.kamelet.yaml)
+
+## Objectives
+
+The test verifies the AWS SQS Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for messages on the
+AWS SQS channel.
+
+This test uses [aws-sqs-docker-image](https://github.com/tplevko/aws-sqs-docker-image) as a test client for extecution of validation steps.
+
+### Test Kamelet source
+
+The test performs the following high level steps:
+
+*Preparation*
+- Create a secret on the current namespace holding the AWS SQS credentials
+- Link the secret to the test
+
+*Scenario* 
+- Create the Kamelet in the current namespace in the cluster
+- Create the Camel-K integration that uses the Kamelet
+- Wait for the Camel-K integration to start and listen for AWS SQS messages
+- Create a new message in the AWS SQS queue
+- Verify that the integration has received the message event
+
+*Cleanup*
+- Delete the Camel-K integration
+- Delete the secret from the current namespacce
+
+## Installation
+
+The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+and running.
+
+You can review the installation steps for the operators in the documentation:
+
+- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
+
+## Preparations
+
+Before you can run the test you have to provide AWS SQS account credentials into the file [aws-sqs-credentials.properties](aws-sqs-credentials.properties). The test will use these credentials to connect to your AWS SQS queue.
+
+When the test is executed the credentials will be automatically added as a secret in the current Kubernetes namespace. The secret is automatically created before the test using
+the shell script [prepare-secret.sh](prepare-secret.sh).
+
+*prepare-secret.sh*
+```shell script
+# create secret from properties file
+kubectl create secret generic aws-sqs-credentials --from-file=aws-sqs-credentials.properties
+
+# bind secret to test by name
+kubectl label secret aws-sqs-credentials yaks.citrusframework.org/test=aws-sqs-source 
+```  
+
+If for any reason this script execution does not work for your OS or environment you may need to run this step manually on your cluster and
+remove the prepare script from the [yaks-config.yaml](yaks-config.yaml).
+
+Now you should be ready to run the test!
+
+## Run the test
+
+```shell script
+$ yaks test aws-sqs-source.feature
+```
+
+You will be provided with the test log output and the test results.

--- a/test/aws-sqs/aws-sqs-client.yaml
+++ b/test/aws-sqs/aws-sqs-client.yaml
@@ -1,0 +1,27 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: aws-sqs-client
+  generateName: aws-sqs-client-
+  labels:
+    app: yaks
+    name: aws-sqs-client
+spec:
+  containers:
+    - name: aws-sqs-client
+      image: 'tplevko/aws-sqs-client:0.1.0'
+      env:
+        - name: AWS_ACCOUNT_ID
+          value: "${aws-sqs.accountId}"
+        - name: AWS_SQS_QUEUE_NAME
+          value: "${aws-sqs.queueNameOrArn}"
+        - name: AWS_REGION
+          value: "${aws-sqs.region}"
+        - name: AWS_ACCESS_KEY_ID
+          value: "${aws-sqs.accessKey}"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "${aws-sqs.secretKey}"
+        - name: AWS_SQS_TEXT
+          value: "${message}"
+      imagePullPolicy: IfNotPresent
+  restartPolicy: Never

--- a/test/aws-sqs/aws-sqs-credentials.properties
+++ b/test/aws-sqs/aws-sqs-credentials.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Please add your AWS SQS account credentials
+aws-sqs.queueNameOrArn=
+aws-sqs.accessKey=
+aws-sqs.secretKey=
+aws-sqs.region=
+aws-sqs.deleteAfterRead=true
+aws-sqs.accountId=

--- a/test/aws-sqs/aws-sqs-source.feature
+++ b/test/aws-sqs/aws-sqs-source.feature
@@ -1,0 +1,22 @@
+Feature: AWS SQS Kamelet
+
+  Background:
+    Given Disable auto removal of Camel resources
+    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Kamelet resources
+
+  Scenario: Create Camel-K resources
+    Given create Camel-K integration sqs-to-log.groovy
+    """
+    from('kamelet:aws-sqs-source?queueNameOrArn=${aws-sqs.queueNameOrArn}&accessKey=${aws-sqs.accessKey}&secretKey=RAW(${aws-sqs.secretKey})&region=${aws-sqs.region}&deleteAfterRead=${aws-sqs.deleteAfterRead}')
+        .to("log:info")
+    """
+
+  Scenario: Verify Kamelet source
+    Given variable message is "Hello from Kamelet source citrus:randomString(10)"
+    When Camel-K integration sqs-to-log is running
+    And load Kubernetes resource aws-sqs-client.yaml
+    Then Camel-K integration sqs-to-log should print "${message}"
+
+  Scenario: Remove Camel-K resources
+    Given delete Camel-K integration sqs-to-log

--- a/test/aws-sqs/delete-secret.sh
+++ b/test/aws-sqs/delete-secret.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# delete secret
+kubectl delete secret aws-sqs-credentials

--- a/test/aws-sqs/prepare-secret.sh
+++ b/test/aws-sqs/prepare-secret.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# create secret from properties file
+kubectl create secret generic aws-sqs-credentials --from-file=aws-sqs-credentials.properties
+
+# bind secret to test by name
+kubectl label secret aws-sqs-credentials yaks.citrusframework.org/test=aws-sqs-source

--- a/test/aws-sqs/sqs-to-log.groovy
+++ b/test/aws-sqs/sqs-to-log.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// camel-k: language=groovy
+
+def parameters = 'queueNameOrArn=${aws-sqs.queueNameOrArn}&'+ 
+                 'accessKey=${aws-sqs.accessKey}&' +
+                 'secretKey=RAW(${aws-sqs.secretKey})&'+
+                 'region=${aws-sqs.region}&'+
+                 'deleteAfterRead=${aws-sqs.deleteAfterRead}'
+
+from("kamelet:aws-sqs-source?$parameters")
+  .to("log:info")

--- a/test/aws-sqs/yaks-config.yaml
+++ b/test/aws-sqs/yaks-config.yaml
@@ -1,0 +1,9 @@
+config:
+  runtime:
+    resources:
+      - ../../aws-sqs-source.kamelet.yaml
+      - aws-sqs-client.yaml
+pre:
+  - script: prepare-secret.sh
+post:
+  - script: delete-secret.sh


### PR DESCRIPTION
The client can be placed to some other place, it's ATM in my repository - https://github.com/tplevko/aws-sqs-docker-image. @christophd - do you think the client could be moved to citrusframework org?