### PR TITLE
fix AWS sqs test queue init and teardown

### DIFF
--- a/test/aws-sqs/aws-sqs-source-property-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-property-conf.feature
@@ -4,6 +4,7 @@ Feature: AWS SQS Kamelet - property based config
     Given Disable auto removal of Camel resources
     Given Disable auto removal of Camel-K resources
     Given Disable auto removal of Kamelet resources
+    Given Disable auto removal of Kubernetes resources
 
   Scenario: Create AWS SQS queue
     Given variables
@@ -33,5 +34,5 @@ Feature: AWS SQS Kamelet - property based config
   Scenario: Remove AWS SQS queue
     Given variables
       | aws.sqs.clientName | aws-sqs-client-citrus:randomString(10, LOWERCASE) |
-      | aws.sqs.command    | "delete-queue", "--queue-name", "${aws.sqs.queueUrl}" |
+      | aws.sqs.command    | "delete-queue", "--queue-url", "${aws.sqs.queueUrl}" |
     Then load Kubernetes resource aws-sqs-client.yaml

--- a/test/aws-sqs/aws-sqs-source-secret-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-secret-conf.feature
@@ -4,6 +4,7 @@ Feature: AWS SQS Kamelet - secret based config
     Given Disable auto removal of Camel resources
     Given Disable auto removal of Camel-K resources
     Given Disable auto removal of Kamelet resources
+    Given Disable auto removal of Kubernetes resources
 
   Scenario: Create AWS SQS queue
     Given variables
@@ -28,5 +29,5 @@ Feature: AWS SQS Kamelet - secret based config
   Scenario: Remove AWS SQS queue
     Given variables
       | aws.sqs.clientName | aws-sqs-client-citrus:randomString(10, LOWERCASE) |
-      | aws.sqs.command    | "delete-queue", "--queue-name", "${aws.sqs.queueUrl}" |
+      | aws.sqs.command    | "delete-queue", "--queue-url", "${aws.sqs.queueUrl}" |
     Then load Kubernetes resource aws-sqs-client.yaml

--- a/test/aws-sqs/aws-sqs-source-uri-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-uri-conf.feature
@@ -4,6 +4,7 @@ Feature: AWS SQS Kamelet - URI based config
     Given Disable auto removal of Camel resources
     Given Disable auto removal of Camel-K resources
     Given Disable auto removal of Kamelet resources
+    Given Disable auto removal of Kubernetes resources
 
   Scenario: Create AWS SQS queue
     Given variables
@@ -28,5 +29,5 @@ Feature: AWS SQS Kamelet - URI based config
   Scenario: Remove AWS SQS queue
     Given variables
       | aws.sqs.clientName | aws-sqs-client-citrus:randomString(10, LOWERCASE) |
-      | aws.sqs.command    | "delete-queue", "--queue-name", "${aws.sqs.queueUrl}" |
+      | aws.sqs.command    | "delete-queue", "--queue-url", "${aws.sqs.queueUrl}" |
     Then load Kubernetes resource aws-sqs-client.yaml

--- a/test/aws-sqs/delete-secret.sh
+++ b/test/aws-sqs/delete-secret.sh
@@ -19,6 +19,5 @@
 oc delete secret aws-sqs-credentials-uri -n ${YAKS_NAMESPACE}
 oc delete secret aws-sqs-credentials-property -n ${YAKS_NAMESPACE}
 oc delete secret aws-sqs-credentials-secret -n ${YAKS_NAMESPACE}
-oc delete secret aws-sqs-source.aws-sqs-credentials -n ${YAKS_NAMESPACE}
 oc delete secret aws-client-config -n ${YAKS_NAMESPACE}
 oc delete secret aws-sqs-credentials-kamelet -n ${YAKS_NAMESPACE}


### PR DESCRIPTION
Adding `Disable auto removal of Kubernetes resources` prevents the AWS CLI pod from being deleted prior to the create and delete command execution.