### PR TITLE
Avoid IOException on constructor 

### DIFF
--- a/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/KameletsCatalog.java
+++ b/library/camel-kamelets-catalog/src/main/java/org/apache/camel/kamelets/catalog/KameletsCatalog.java
@@ -46,26 +46,30 @@ import java.util.stream.Collectors;
 public class KameletsCatalog {
 
     private static final Logger LOG = LoggerFactory.getLogger(KameletsCatalog.class);
-    private static final String KAMELETS_DIR = "kamelets";
+    static final String KAMELETS_DIR = "kamelets";
     private static final String KAMELETS_FILE_SUFFIX = ".kamelet.yaml";
     private static ObjectMapper mapper = new ObjectMapper(new YAMLFactory()).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private Map<String, Kamelet> kameletModels = new HashMap<>();
     private List<String> kameletNames = new ArrayList<>();
 
-    public KameletsCatalog() throws IOException {
+    public KameletsCatalog() {
         initCatalog();
         kameletNames = kameletModels.keySet().stream().sorted(Comparator.naturalOrder()).map(x -> x).collect(Collectors.toList());
     }
 
-    private void initCatalog() throws IOException {
+    private void initCatalog() {
         List<String> resourceNames;
         try (ScanResult scanResult = new ClassGraph().acceptPaths("/" + KAMELETS_DIR + "/").scan()) {
             resourceNames = scanResult.getAllResources().getPaths();
         }
-        for (String fileName:
-                resourceNames) {
-            Kamelet kamelet = mapper.readValue(KameletsCatalog.class.getResourceAsStream("/" + fileName), Kamelet.class);
-            kameletModels.put(sanitizeFileName(fileName), kamelet);
+        for (String fileName: resourceNames) {
+            String pathInJar = "/" + fileName;
+            try {
+                Kamelet kamelet = mapper.readValue(KameletsCatalog.class.getResourceAsStream(pathInJar), Kamelet.class);
+                kameletModels.put(sanitizeFileName(fileName), kamelet);
+            } catch (IOException e) {
+                LOG.warn("Cannot init Kamelet Catalog with content of " + pathInJar, e);
+            }
         }
     }
 

--- a/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
+++ b/library/camel-kamelets-catalog/src/test/java/org/apache/camel/kamelets/catalog/KameletsCatalogTest.java
@@ -19,24 +19,25 @@ package org.apache.camel.kamelets.catalog;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.camelk.v1alpha1.Kamelet;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
-import org.apache.camel.kamelets.catalog.model.KameletTypeEnum;
+
+import io.github.classgraph.ClassGraph;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Map;
+
 public class KameletsCatalogTest {
     static KameletsCatalog catalog;
 
     @BeforeAll
-    public static void createKameletsCatalog() throws IOException {
+    public static void createKameletsCatalog() {
         catalog = new KameletsCatalog();
     }
 
@@ -94,4 +95,11 @@ public class KameletsCatalogTest {
         JsonNode flow = catalog.getKameletFlow("aws-sqs-source");
         assertNotNull(flow);
     }
+    
+    @Test
+    void testAllKameletFilesLoaded() throws Exception {
+        int numberOfKameletFiles = new ClassGraph().acceptPaths("/" + KameletsCatalog.KAMELETS_DIR + "/").scan().getAllResources().size();
+        assertEquals(numberOfKameletFiles, catalog.getKameletsName().size(), "Some embedded kamelet definition files cannot be loaded.");
+    }
+
 }


### PR DESCRIPTION
- when a kamelet file cannot be loaded, a log is provided but other
files still can load
- provided a test to ensure that we are not embedding some kamelet files
that are invalid and that we won't detect anymore with existing tests

Signed-off-by: Aurélien Pupier <apupier@redhat.com>