### PR TITLE
Backport: Fixed invalid connection URL parameter in JMS AMQP Kamelets (#126)

### DIFF
--- a/docs/modules/ROOT/pages/jms-amqp-10-sink.adoc
+++ b/docs/modules/ROOT/pages/jms-amqp-10-sink.adoc
@@ -11,8 +11,8 @@ The following table summarizes the configuration options available for the `jms-
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *brokerURL {empty}* *| Broker URL| The JMS URL| string| | `"amqp://k3s-node-master.usersys.redhat.com:31616"`
 | *destinationName {empty}* *| Destination Name| The JMS destination name| string| | 
+| *remoteURI {empty}* *| Broker URL| The JMS URL| string| | `"amqp://my-host:31616"`
 | destinationType| Destination Type| The JMS destination type (i.e.: queue or topic)| string| `"queue"`| 
 |===
 
@@ -45,8 +45,8 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: jms-amqp-10-sink
     properties:
-      brokerURL: "amqp://k3s-node-master.usersys.redhat.com:31616"
       destinationName: "The Destination Name"
+      remoteURI: "amqp://my-host:31616"
 
 ----
 
@@ -67,7 +67,7 @@ The procedure described above can be simplified into a single execution of the `
 
 [source,shell]
 ----
-kamel bind channel/mychannel jms-amqp-10-sink -p "sink.brokerURL=amqp://k3s-node-master.usersys.redhat.com:31616" -p "sink.destinationName=The Destination Name"
+kamel bind channel/mychannel jms-amqp-10-sink -p "sink.destinationName=The Destination Name" -p "sink.remoteURI=amqp://my-host:31616"
 ----
 
 This will create the KameletBinding under the hood and apply it to the current namespace in the cluster.
@@ -95,8 +95,8 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: jms-amqp-10-sink
     properties:
-      brokerURL: "amqp://k3s-node-master.usersys.redhat.com:31616"
       destinationName: "The Destination Name"
+      remoteURI: "amqp://my-host:31616"
 
 ----
 
@@ -118,7 +118,7 @@ The procedure described above can be simplified into a single execution of the `
 
 [source,shell]
 ----
-kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic jms-amqp-10-sink -p "sink.brokerURL=amqp://k3s-node-master.usersys.redhat.com:31616" -p "sink.destinationName=The Destination Name"
+kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic jms-amqp-10-sink -p "sink.destinationName=The Destination Name" -p "sink.remoteURI=amqp://my-host:31616"
 ----
 
 This will create the KameletBinding under the hood and apply it to the current namespace in the cluster.

--- a/docs/modules/ROOT/pages/jms-amqp-10-source.adoc
+++ b/docs/modules/ROOT/pages/jms-amqp-10-source.adoc
@@ -11,8 +11,8 @@ The following table summarizes the configuration options available for the `jms-
 [width="100%",cols="2,^2,3,^2,^2,^3",options="header"]
 |===
 | Property| Name| Description| Type| Default| Example
-| *brokerURL {empty}* *| Broker URL| The JMS URL| string| | `"amqp://k3s-node-master.usersys.redhat.com:31616"`
 | *destinationName {empty}* *| Destination Name| The JMS destination name| string| | 
+| *remoteURI {empty}* *| Broker URL| The JMS URL| string| | `"amqp://my-host:31616"`
 | destinationType| Destination Type| The JMS destination type (i.e.: queue or topic)| string| `"queue"`| 
 |===
 
@@ -40,8 +40,8 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: jms-amqp-10-source
     properties:
-      brokerURL: "amqp://k3s-node-master.usersys.redhat.com:31616"
       destinationName: "The Destination Name"
+      remoteURI: "amqp://my-host:31616"
   sink:
     ref:
       kind: InMemoryChannel
@@ -67,7 +67,7 @@ The procedure described above can be simplified into a single execution of the `
 
 [source,shell]
 ----
-kamel bind jms-amqp-10-source -p "source.brokerURL=amqp://k3s-node-master.usersys.redhat.com:31616" -p "source.destinationName=The Destination Name" channel/mychannel
+kamel bind jms-amqp-10-source -p "source.destinationName=The Destination Name" -p "source.remoteURI=amqp://my-host:31616" channel/mychannel
 ----
 
 This will create the KameletBinding under the hood and apply it to the current namespace in the cluster.
@@ -90,8 +90,8 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: jms-amqp-10-source
     properties:
-      brokerURL: "amqp://k3s-node-master.usersys.redhat.com:31616"
       destinationName: "The Destination Name"
+      remoteURI: "amqp://my-host:31616"
   sink:
     ref:
       kind: KafkaTopic
@@ -118,7 +118,7 @@ The procedure described above can be simplified into a single execution of the `
 
 [source,shell]
 ----
-kamel bind jms-amqp-10-source -p "source.brokerURL=amqp://k3s-node-master.usersys.redhat.com:31616" -p "source.destinationName=The Destination Name" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
+kamel bind jms-amqp-10-source -p "source.destinationName=The Destination Name" -p "source.remoteURI=amqp://my-host:31616" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
 ----
 
 This will create the KameletBinding under the hood and apply it to the current namespace in the cluster.

--- a/jms-amqp-10-sink.kamelet.yaml
+++ b/jms-amqp-10-sink.kamelet.yaml
@@ -16,7 +16,7 @@ spec:
     description: "A Kamelet that can produce events to any AMQP 1.0 compliant message broker using the Apache Qpid JMS client"
     required:
       - destinationName
-      - brokerURL
+      - remoteURI
     type: object
     properties:
       destinationType:
@@ -28,11 +28,11 @@ spec:
         title: "Destination Name"
         description: "The JMS destination name"
         type: string
-      brokerURL:
+      remoteURI:
         title: "Broker URL"
         description: "The JMS URL"
         type: string
-        example: "amqp://k3s-node-master.usersys.redhat.com:31616"
+        example: "amqp://my-host:31616"
   dependencies:
   - "camel:jms"
   - "camel:kamelet"

--- a/jms-amqp-10-source.kamelet.yaml
+++ b/jms-amqp-10-source.kamelet.yaml
@@ -16,7 +16,7 @@ spec:
     description: "A Kamelet that can consume events from any AMQP 1.0 compliant message broker using the Apache Qpid JMS client"
     required:
       - destinationName
-      - brokerURL
+      - remoteURI
     type: object
     properties:
       destinationType:
@@ -28,11 +28,11 @@ spec:
         title: "Destination Name"
         description: "The JMS destination name"
         type: string
-      brokerURL:
+      remoteURI:
         title: "Broker URL"
         description: "The JMS URL"
         type: string
-        example: "amqp://k3s-node-master.usersys.redhat.com:31616"
+        example: "amqp://my-host:31616"
   dependencies:
   - "camel:jms"
   - "camel:kamelet"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
@@ -16,7 +16,7 @@ spec:
     description: "A Kamelet that can produce events to any AMQP 1.0 compliant message broker using the Apache Qpid JMS client"
     required:
       - destinationName
-      - brokerURL
+      - remoteURI
     type: object
     properties:
       destinationType:
@@ -28,11 +28,11 @@ spec:
         title: "Destination Name"
         description: "The JMS destination name"
         type: string
-      brokerURL:
+      remoteURI:
         title: "Broker URL"
         description: "The JMS URL"
         type: string
-        example: "amqp://k3s-node-master.usersys.redhat.com:31616"
+        example: "amqp://my-host:31616"
   dependencies:
   - "camel:jms"
   - "camel:kamelet"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
@@ -16,7 +16,7 @@ spec:
     description: "A Kamelet that can consume events from any AMQP 1.0 compliant message broker using the Apache Qpid JMS client"
     required:
       - destinationName
-      - brokerURL
+      - remoteURI
     type: object
     properties:
       destinationType:
@@ -28,11 +28,11 @@ spec:
         title: "Destination Name"
         description: "The JMS destination name"
         type: string
-      brokerURL:
+      remoteURI:
         title: "Broker URL"
         description: "The JMS URL"
         type: string
-        example: "amqp://k3s-node-master.usersys.redhat.com:31616"
+        example: "amqp://my-host:31616"
   dependencies:
   - "camel:jms"
   - "camel:kamelet"


### PR DESCRIPTION
In some scenarios - outside Camel K - it could prevent the template and
 its parameters from being correctly resolved