### PR TITLE
ENTESB-17076: downgrade qpid library

### DIFF
--- a/jms-amqp-10-sink.kamelet.yaml
+++ b/jms-amqp-10-sink.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
-  - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
+  - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
   flow:
     beans:
       - name: connectionFactoryBean

--- a/jms-amqp-10-source.kamelet.yaml
+++ b/jms-amqp-10-source.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
-  - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
+  - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
   flow:
     beans:
       - name: connectionFactoryBean

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
-  - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
+  - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
   flow:
     beans:
       - name: connectionFactoryBean

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
   dependencies:
   - "camel:jms"
   - "camel:kamelet"
-  - "mvn:org.apache.qpid:qpid-jms-client:1.0.0"
+  - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
   flow:
     beans:
       - name: connectionFactoryBean

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- These properties must keep this same format "version.<groupId>.<artifactId>" -->
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
         <version.org.apache.commons.commons-dbcp2>2.7.0</version.org.apache.commons.commons-dbcp2>
-        <version.org.apache.qpid.qpid-jms-client>1.0.0</version.org.apache.qpid.qpid-jms-client>
+        <version.org.apache.qpid.qpid-jms-client>0.55.0</version.org.apache.qpid.qpid-jms-client>
 
     </properties>
 


### PR DESCRIPTION
I've tested both 0.55.0 and 0.55.0.redhat-00005 versions with CK8.