### PR TITLE
chore: Run publish workflow only on parent repository

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-pages:
     runs-on: ubuntu-latest
+    if: github.repository == 'openshift-integration/kamelet-catalog'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Avoid running workflow on forked repositories. It will fail anyway when not run on the parent repository