### PR TITLE
fix: Fix Maven artifact version of parent POM

### DIFF
--- a/library/camel-kamelets-bom/pom.xml
+++ b/library/camel-kamelets-bom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.kamelets</groupId>
         <artifactId>camel-kamelets-parent</artifactId>
-        <version>main-SNAPSHOT</version>
+        <version>master-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Should also stabilize continuous test workflow, because Jitpack dependencies in YAKS tests start to work again