### PR TITLE
chore: use .spec.template in favour of deprecated .spec.flow

### DIFF
--- a/avro-deserialize-action.kamelet.yaml
+++ b/avro-deserialize-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/avro-serialize-action.kamelet.yaml
+++ b/avro-serialize-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-cloudwatch-sink.kamelet.yaml
+++ b/aws-cloudwatch-sink.kamelet.yaml
@@ -56,7 +56,7 @@ spec:
   dependencies:
     - "camel:aws2-cw"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-ddb-streams-source.kamelet.yaml
+++ b/aws-ddb-streams-source.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
   - "camel:kamelet"
   - "camel:aws2-ddb"
   - "camel:gson"
-  flow:
+  template:
     from:
       uri: "aws2-ddbstream:{{table}}"
       parameters:

--- a/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/aws-kinesis-firehose-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-kinesis"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-kinesis-sink.kamelet.yaml
+++ b/aws-kinesis-sink.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-kinesis-source.kamelet.yaml
+++ b/aws-kinesis-source.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - "camel:gson"
   - "camel:kamelet"
   - "camel:aws2-kinesis"
-  flow:
+  template:
     from:
       uri: aws2-kinesis:{{stream}}
       parameters:

--- a/aws-lambda-sink.kamelet.yaml
+++ b/aws-lambda-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-lambda"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-s3-sink.kamelet.yaml
+++ b/aws-s3-sink.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/aws-s3-source.kamelet.yaml
+++ b/aws-s3-source.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-s3"
-  flow:
+  template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"
       parameters:

--- a/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/aws-sns-sink.kamelet.yaml
+++ b/aws-sns-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-sns"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-sqs-fifo-sink.kamelet.yaml
+++ b/aws-sqs-fifo-sink.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-sqs-sink.kamelet.yaml
+++ b/aws-sqs-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/aws-sqs-source.kamelet.yaml
+++ b/aws-sqs-source.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:

--- a/azure-storage-blob-sink.kamelet.yaml
+++ b/azure-storage-blob-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   dependencies:
   - "camel:azure-storage-blob"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/azure-storage-blob-source.kamelet.yaml
+++ b/azure-storage-blob-source.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   - "camel:core"
   - "camel:timer"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "timer:azure-storage-blob-stream"
       parameters:

--- a/azure-storage-queue-sink.kamelet.yaml
+++ b/azure-storage-queue-sink.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
   dependencies:
   - "camel:azure-storage-queue"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/azure-storage-queue-source.kamelet.yaml
+++ b/azure-storage-queue-source.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "azure-storage-queue://{{accountName}}/{{queueName}}"
       parameters:

--- a/cassandra-sink.kamelet.yaml
+++ b/cassandra-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/cassandra-source.kamelet.yaml
+++ b/cassandra-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:

--- a/elasticsearch-index-sink.kamelet.yaml
+++ b/elasticsearch-index-sink.kamelet.yaml
@@ -85,7 +85,7 @@ spec:
     - "camel:elasticsearch-rest"
     - "camel:gson"
     - "camel:bean"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/extract-field-action.kamelet.yaml
+++ b/extract-field-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/ftp-sink.kamelet.yaml
+++ b/ftp-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/ftp-source.kamelet.yaml
+++ b/ftp-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/ftps-sink.kamelet.yaml
+++ b/ftps-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/ftps-source.kamelet.yaml
+++ b/ftps-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/has-header-filter-action.kamelet.yaml
+++ b/has-header-filter-action.kamelet.yaml
@@ -25,7 +25,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/hoist-field-action.kamelet.yaml
+++ b/hoist-field-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/http-sink.kamelet.yaml
+++ b/http-sink.kamelet.yaml
@@ -32,7 +32,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/insert-field-action.kamelet.yaml
+++ b/insert-field-action.kamelet.yaml
@@ -31,7 +31,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/insert-header-action.kamelet.yaml
+++ b/insert-header-action.kamelet.yaml
@@ -29,7 +29,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/is-tombstone-filter-action.kamelet.yaml
+++ b/is-tombstone-filter-action.kamelet.yaml
@@ -17,7 +17,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/jira-source.kamelet.yaml
+++ b/jira-source.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:jira"
-  flow:
+  template:
     from:
       uri: "jira:newIssues"
       parameters:

--- a/jms-amqp-10-sink.kamelet.yaml
+++ b/jms-amqp-10-sink.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/jms-amqp-10-source.kamelet.yaml
+++ b/jms-amqp-10-source.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/json-deserialize-action.kamelet.yaml
+++ b/json-deserialize-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/json-serialize-action.kamelet.yaml
+++ b/json-serialize-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kafka-manual-commit-action.kamelet.yaml
+++ b/kafka-manual-commit-action.kamelet.yaml
@@ -17,7 +17,7 @@ spec:
   dependencies:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/kafka-sink.kamelet.yaml
+++ b/kafka-sink.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/kafka-source.kamelet.yaml
+++ b/kafka-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-avro"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-cloudwatch-sink.kamelet.yaml
@@ -56,7 +56,7 @@ spec:
   dependencies:
     - "camel:aws2-cw"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
   - "camel:kamelet"
   - "camel:aws2-ddb"
   - "camel:gson"
-  flow:
+  template:
     from:
       uri: "aws2-ddbstream:{{table}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-firehose-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-kinesis"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-sink.kamelet.yaml
@@ -59,7 +59,7 @@ spec:
   dependencies:
     - "camel:aws2-kinesis"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-kinesis-source.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
   - "camel:gson"
   - "camel:kamelet"
   - "camel:aws2-kinesis"
-  flow:
+  template:
     from:
       uri: aws2-kinesis:{{stream}}
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-lambda-sink.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-lambda"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-sink.kamelet.yaml
@@ -60,7 +60,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-source.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-s3"
-  flow:
+  template:
     from:
       uri: "aws2-s3:{{bucketNameOrArn}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-s3-streaming-upload-sink.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
   dependencies:
     - "camel:aws2-s3"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sns-sink.kamelet.yaml
@@ -54,7 +54,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:aws2-sns"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-fifo-sink.kamelet.yaml
@@ -62,7 +62,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-sink.kamelet.yaml
@@ -55,7 +55,7 @@ spec:
   - "camel:aws2-sqs"
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-sqs-source.kamelet.yaml
@@ -66,7 +66,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "aws2-sqs:{{queueNameOrArn}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-blob-sink.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   dependencies:
   - "camel:azure-storage-blob"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-blob-source.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
   - "camel:core"
   - "camel:timer"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "timer:azure-storage-blob-stream"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-queue-sink.kamelet.yaml
@@ -46,7 +46,7 @@ spec:
   dependencies:
   - "camel:azure-storage-queue"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/azure-storage-queue-source.kamelet.yaml
@@ -43,7 +43,7 @@ spec:
   dependencies:
     - "camel:azure-storage-queue"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "azure-storage-queue://{{accountName}}/{{queueName}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/cassandra-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/cassandra-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/cassandra-source.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:cassandraql"
-  flow:
+  template:
     from:
       uri: "cql://{{connectionHost}}:{{connectionPort}}/{{keyspace}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/elasticsearch-index-sink.kamelet.yaml
@@ -85,7 +85,7 @@ spec:
     - "camel:elasticsearch-rest"
     - "camel:gson"
     - "camel:bean"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/ftp-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/ftp-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/ftp-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/ftp-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/ftps-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/ftps-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/ftps-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/ftps-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "ftps:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/has-header-filter-action.kamelet.yaml
@@ -25,7 +25,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/http-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/http-sink.kamelet.yaml
@@ -32,7 +32,7 @@ spec:
   - "camel:http"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-field-action.kamelet.yaml
@@ -31,7 +31,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-header-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-header-action.kamelet.yaml
@@ -29,7 +29,7 @@ spec:
   dependencies:
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/is-tombstone-filter-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/is-tombstone-filter-action.kamelet.yaml
@@ -17,7 +17,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jira-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jira-source.kamelet.yaml
@@ -49,7 +49,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:jira"
-  flow:
+  template:
     from:
       uri: "jira:newIssues"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-sink.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-amqp-10-source.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:jms"
   - "camel:kamelet"
   - "mvn:org.apache.qpid:qpid-jms-client:0.55.0"
-  flow:
+  template:
     beans:
       - name: connectionFactoryBean
         type: "#class:org.apache.qpid.jms.JmsConnectionFactory"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
@@ -18,7 +18,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-manual-commit-action.kamelet.yaml
@@ -17,7 +17,7 @@ spec:
   dependencies:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-sink.kamelet.yaml
@@ -61,7 +61,7 @@ spec:
   dependencies:
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/kafka-source.kamelet.yaml
@@ -86,7 +86,7 @@ spec:
     - "camel:core"
     - "camel:kafka"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kafka:{{topic}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/log-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/log-sink.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:log"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mariadb-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:org.mariadb.jdbc:mariadb-java-client"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mask-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mask-field-action.kamelet.yaml
@@ -31,7 +31,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mongodb-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mongodb-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mongodb-source.kamelet.yaml
@@ -64,7 +64,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mysql-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mysql-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:mysql:mysql-connector-java"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/postgresql-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/predicate-filter-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/predicate-filter-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/regex-router-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/regex-router-action.kamelet.yaml
@@ -30,7 +30,7 @@ spec:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/replace-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/replace-field-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/salesforce-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/salesforce-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:salesforce"
   - "mvn:org.apache.camel.k:camel-k-kamelet-reify"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet-reify:salesforce:{{topicName}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/sftp-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/sftp-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/sftp-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/sftp-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "sftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/slack-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/slack-source.kamelet.yaml
@@ -38,7 +38,7 @@ spec:
   - "camel:kamelet"
   - "camel:slack"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "slack:{{channel}}"
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/sqlserver-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre11"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/telegram-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/telegram-source.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
     - "camel:kamelet"
     - "camel:telegram"
     - "camel:core"
-  flow:
+  template:
     from:
       uri: telegram:bots
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/timer-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/timer-source.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
     - "camel:core"
     - "camel:timer"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: timer:tick
       parameters:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/timestamp-router-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/topic-name-matches-filter-action.kamelet.yaml
@@ -24,7 +24,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/log-sink.kamelet.yaml
+++ b/log-sink.kamelet.yaml
@@ -33,7 +33,7 @@ spec:
   dependencies:
   - "camel:kamelet"
   - "camel:log"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/mariadb-sink.kamelet.yaml
+++ b/mariadb-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:org.mariadb.jdbc:mariadb-java-client"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/mask-field-action.kamelet.yaml
+++ b/mask-field-action.kamelet.yaml
@@ -31,7 +31,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/message-timestamp-router-action.kamelet.yaml
+++ b/message-timestamp-router-action.kamelet.yaml
@@ -41,7 +41,7 @@ spec:
   - "camel:jackson"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/mongodb-sink.kamelet.yaml
+++ b/mongodb-sink.kamelet.yaml
@@ -67,7 +67,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/mongodb-source.kamelet.yaml
+++ b/mongodb-source.kamelet.yaml
@@ -64,7 +64,7 @@ spec:
     - "camel:kamelet"
     - "camel:mongodb"
     - "camel:jackson"
-  flow:
+  template:
     beans:
       - name: local-mongodb
         type: "#class:org.apache.camel.component.mongodb.MongoDbComponent"

--- a/mysql-sink.kamelet.yaml
+++ b/mysql-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:mysql:mysql-connector-java"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/postgresql-sink.kamelet.yaml
+++ b/postgresql-sink.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
   - "camel:sql"
   - "mvn:org.postgresql:postgresql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/predicate-filter-action.kamelet.yaml
+++ b/predicate-filter-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:kamelet"
   - "camel:jsonpath"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/protobuf-deserialize-action.kamelet.yaml
+++ b/protobuf-deserialize-action.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/protobuf-serialize-action.kamelet.yaml
+++ b/protobuf-serialize-action.kamelet.yaml
@@ -27,7 +27,7 @@ spec:
   - "camel:kamelet"
   - "camel:core"
   - "camel:jackson-protobuf"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/regex-router-action.kamelet.yaml
+++ b/regex-router-action.kamelet.yaml
@@ -30,7 +30,7 @@ spec:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/replace-field-action.kamelet.yaml
+++ b/replace-field-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/salesforce-source.kamelet.yaml
+++ b/salesforce-source.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
   - "camel:salesforce"
   - "mvn:org.apache.camel.k:camel-k-kamelet-reify"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet-reify:salesforce:{{topicName}}"
       parameters:

--- a/sftp-sink.kamelet.yaml
+++ b/sftp-sink.kamelet.yaml
@@ -68,7 +68,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/sftp-source.kamelet.yaml
+++ b/sftp-source.kamelet.yaml
@@ -71,7 +71,7 @@ spec:
     - "camel:ftp"
     - "camel:core"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: "sftp:{{username}}@{{connectionHost}}:{{connectionPort}}/{{directoryName}}"
       parameters:

--- a/slack-source.kamelet.yaml
+++ b/slack-source.kamelet.yaml
@@ -38,7 +38,7 @@ spec:
   - "camel:kamelet"
   - "camel:slack"
   - "camel:jackson"
-  flow:
+  template:
     from:
       uri: "slack:{{channel}}"
       parameters:

--- a/sqlserver-sink.kamelet.yaml
+++ b/sqlserver-sink.kamelet.yaml
@@ -70,7 +70,7 @@ spec:
   - "camel:sql"
   - "mvn:org.apache.commons:commons-dbcp2:2.7.0"
   - "mvn:com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre11"
-  flow:
+  template:
     beans:
       - name: dsBean
         type: "#class:org.apache.commons.dbcp2.BasicDataSource"

--- a/telegram-source.kamelet.yaml
+++ b/telegram-source.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
     - "camel:kamelet"
     - "camel:telegram"
     - "camel:core"
-  flow:
+  template:
     from:
       uri: telegram:bots
       parameters:

--- a/test/jira/logger-sink.kamelet.yaml
+++ b/test/jira/logger-sink.kamelet.yaml
@@ -36,7 +36,7 @@ spec:
       mediaType: text/plain
     out:
       mediaType: text/plain
-  flow:
+  template:
     from:
       uri: "kamelet:source"
       steps:

--- a/timer-source.kamelet.yaml
+++ b/timer-source.kamelet.yaml
@@ -53,7 +53,7 @@ spec:
     - "camel:core"
     - "camel:timer"
     - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: timer:tick
       parameters:

--- a/timestamp-router-action.kamelet.yaml
+++ b/timestamp-router-action.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
   - "github:openshift-integration.kamelet-catalog:camel-kamelets-utils:kamelet-catalog-1.6-SNAPSHOT"
   - "camel:kamelet"
   - "camel:core"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/topic-name-matches-filter-action.kamelet.yaml
+++ b/topic-name-matches-filter-action.kamelet.yaml
@@ -24,7 +24,7 @@ spec:
   dependencies:
   - "camel:core"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:

--- a/value-to-key-action.kamelet.yaml
+++ b/value-to-key-action.kamelet.yaml
@@ -26,7 +26,7 @@ spec:
   - "camel:core"
   - "camel:jackson"
   - "camel:kamelet"
-  flow:
+  template:
     from:
       uri: kamelet:source
       steps:


### PR DESCRIPTION
The deprecated field will be soon be removed, so we better change its definition.