### PR TITLE
[Backport] chore: Use "Camel K" instead of "Camel-K" in test steps

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -31,8 +31,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      YAKS_IMAGE_NAME: "docker.io/citrusframework/yaks"
-      YAKS_VERSION: "0.8.0"
+      YAKS_IMAGE_NAME: "docker.io/yaks/yaks"
+      YAKS_VERSION: "0.9.0-202202040021"
       YAKS_RUN_OPTIONS: "--timeout=15m"
       KUBECTL_WAIT_TIMEOUT: "180s"
     steps:
@@ -85,7 +85,7 @@ jobs:
       - name: YAKS tools
         uses: citrusframework/yaks-install-action@v1.0
         with:
-          version: v${{ env.YAKS_VERSION }}
+          version: ${{ env.YAKS_VERSION }}
       - name: Install YAKS
         run: |
           yaks install --operator-image $YAKS_IMAGE_NAME:$YAKS_VERSION

--- a/test/aws-kinesis/README.md
+++ b/test/aws-kinesis/README.md
@@ -4,7 +4,7 @@ This test verifies the AWS Kinesis Kamelet source defined in [aws-kinesis-source
 
 ## Objectives
 
-The test verifies the AWS Kinesis Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for messages on the
+The test verifies the AWS Kinesis Kamelet source by creating a Camel K integration that uses the Kamelet and listens for messages on the
 AWS Kinesis data stream.
 
 ### Test Kamelet source
@@ -18,24 +18,24 @@ The test performs the following high level steps:
 *Scenario* 
 - Create a new AWS Kinesis data stream for testing
 - Create the Kamelet in the current namespace in the cluster
-- Create the Camel-K integration that uses the Kamelet
-- Wait for the Camel-K integration to start and listen for AWS Kinesis data stream
+- Create the Camel K integration that uses the Kamelet
+- Wait for the Camel K integration to start and listen for AWS Kinesis data stream
 - Create a new message on the AWS Kinesis data stream
 - Verify that the integration has received the message event
 
 *Cleanup*
 - Delete the AWS Kinesis data stream
-- Delete the Camel-K integration
+- Delete the Camel K integration
 - Delete the secret from the current namespace
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/aws-kinesis/aws-kinesis-inmem-binding.feature
+++ b/test/aws-kinesis/aws-kinesis-inmem-binding.feature
@@ -2,7 +2,7 @@ Feature: AWS-Kinesis Kamelet
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -18,21 +18,21 @@ Feature: AWS-Kinesis Kamelet
     Then KameletBinding aws-kinesis-to-inmem should be available
     Given load KameletBinding inmem-to-log.yaml
     And KameletBinding inmem-to-log should be available
-    And Camel-K integration aws-kinesis-to-inmem is running
-    And Camel-K integration inmem-to-log is running
+    And Camel K integration aws-kinesis-to-inmem is running
+    And Camel K integration inmem-to-log is running
 
-    And Camel-K integration aws-kinesis-to-inmem should print Installed features
-    And Camel-K integration inmem-to-log should print Installed features
+    And Camel K integration aws-kinesis-to-inmem should print Installed features
+    And Camel K integration inmem-to-log should print Installed features
     Then sleep 10000 ms
 
     Given variable aws.kinesis.streamData is "abc"
     Given Camel exchange message header CamelAwsKinesisPartitionKey="${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.partitionKey}"
     Given Camel exchange body: ${aws.kinesis.streamData}
-    When Camel-K integration aws-kinesis-to-inmem is running
+    When Camel K integration aws-kinesis-to-inmem is running
     And send Camel exchange to("aws2-kinesis:${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}?accessKey=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.secretKey})&region=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.region}")
-    Then Camel-K integration inmem-to-log should print "data":{"bytes":[97,98,99]
+    Then Camel K integration inmem-to-log should print "data":{"bytes":[97,98,99]
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given variables
       | aws.kinesis.clientName | aws-kinesis-client-citrus:randomString(10, LOWERCASE) |
       | aws.kinesis.command    | "delete-stream", "--stream-name", "${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}" |

--- a/test/aws-kinesis/aws-kinesis-source-prop-based.feature
+++ b/test/aws-kinesis/aws-kinesis-source-prop-based.feature
@@ -2,7 +2,7 @@ Feature: AWS Kinesis Kamelet
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,9 +12,9 @@ Feature: AWS Kinesis Kamelet
     | aws.kinesis.command    | "create-stream", "--stream-name", "${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}", "--shard-count", "1" |
     When load Kubernetes resource aws-kinesis-client.yaml
 
-  Scenario: Create Camel-K resources - property based config
-    Given Camel-K integration property file aws-kinesis-credentials.properties
-    Given create Camel-K integration aws-kinesis-to-log-prop-based.groovy
+  Scenario: Create Camel K resources - property based config
+    Given Camel K integration property file aws-kinesis-credentials.properties
+    Given create Camel K integration aws-kinesis-to-log-prop-based.groovy
     """
     from("kamelet:aws-kinesis-source/aws-kinesis-credentials")
     .to('log:info')
@@ -25,13 +25,13 @@ Feature: AWS Kinesis Kamelet
     Given variable aws.kinesis.streamData is "abc"
     Given Camel exchange message header CamelAwsKinesisPartitionKey="${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.partitionKey}"
     Given Camel exchange body: ${aws.kinesis.streamData}
-    When Camel-K integration aws-kinesis-to-log-prop-based is running
+    When Camel K integration aws-kinesis-to-log-prop-based is running
     Then sleep 10000 ms
     And send Camel exchange to("aws2-kinesis:${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}?accessKey=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.secretKey})&region=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.region}")
-    Then Camel-K integration aws-kinesis-to-log-prop-based should print "data":{"bytes":[97,98,99]
+    Then Camel K integration aws-kinesis-to-log-prop-based should print "data":{"bytes":[97,98,99]
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-kinesis-to-log-prop-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-kinesis-to-log-prop-based
 
   Scenario: Remove AWS Kinesis data stream
     Given variables

--- a/test/aws-kinesis/aws-kinesis-source-secret-based.feature
+++ b/test/aws-kinesis/aws-kinesis-source-secret-based.feature
@@ -2,7 +2,7 @@ Feature: AWS Kinesis Kamelet
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,8 +12,8 @@ Feature: AWS Kinesis Kamelet
     | aws.kinesis.command    | "create-stream", "--stream-name", "${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}", "--shard-count", "1" |
     When load Kubernetes resource aws-kinesis-client.yaml
 
-  Scenario: Create Camel-K resources - secret based config
-    Given create Camel-K integration aws-kinesis-to-log-secret-based.groovy
+  Scenario: Create Camel K resources - secret based config
+    Given create Camel K integration aws-kinesis-to-log-secret-based.groovy
     """
     from("kamelet:aws-kinesis-source/aws-kinesis-credentials")
     .to('log:info')
@@ -24,13 +24,13 @@ Feature: AWS Kinesis Kamelet
     Given variable aws.kinesis.streamData is "abc"
     Given Camel exchange message header CamelAwsKinesisPartitionKey="${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.partitionKey}"
     Given Camel exchange body: ${aws.kinesis.streamData}
-    When Camel-K integration aws-kinesis-to-log-secret-based is running
+    When Camel K integration aws-kinesis-to-log-secret-based is running
     Then sleep 10000 ms
     And send Camel exchange to("aws2-kinesis:${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}?accessKey=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.secretKey})&region=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.region}")
-    Then Camel-K integration aws-kinesis-to-log-secret-based should print "data":{"bytes":[97,98,99]
+    Then Camel K integration aws-kinesis-to-log-secret-based should print "data":{"bytes":[97,98,99]
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-kinesis-to-log-secret-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-kinesis-to-log-secret-based
 
   Scenario: Remove AWS Kinesis data stream
     Given variables

--- a/test/aws-kinesis/aws-kinesis-source-uri-based.feature
+++ b/test/aws-kinesis/aws-kinesis-source-uri-based.feature
@@ -2,7 +2,7 @@ Feature: AWS Kinesis Kamelet
 #TODO blocked by ENTESB-15095
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -14,8 +14,8 @@ Feature: AWS Kinesis Kamelet
     When load Kubernetes resource aws-kinesis-client.yaml
 
   @ignored
-  Scenario: Create Camel-K resources - uri based config
-    And load Camel-K integration aws-kinesis-to-log-uri-based.groovy
+  Scenario: Create Camel K resources - uri based config
+    And load Camel K integration aws-kinesis-to-log-uri-based.groovy
     Then Kamelet aws-kinesis-source is available
 
   @ignored
@@ -23,14 +23,14 @@ Feature: AWS Kinesis Kamelet
     Given variable aws.kinesis.streamData is "abc"
     Given Camel exchange message header CamelAwsKinesisPartitionKey="${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.partitionKey}"
     Given Camel exchange body: ${aws.kinesis.streamData}
-    When Camel-K integration aws-kinesis-to-log-uri-based is running
+    When Camel K integration aws-kinesis-to-log-uri-based is running
     Then sleep 10000 ms
     And send Camel exchange to("aws2-kinesis:${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}?accessKey=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.secretKey})&region=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.region}")
-    Then Camel-K integration aws-kinesis-to-log-uri-based should print "data":{"bytes":[97,98,99]
+    Then Camel K integration aws-kinesis-to-log-uri-based should print "data":{"bytes":[97,98,99]
 
   @ignored
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-kinesis-to-log-uri-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-kinesis-to-log-uri-based
 
   @ignored
   Scenario: Remove AWS Kinesis data stream

--- a/test/aws-kinesis/aws-kinesis-uri-binding.feature
+++ b/test/aws-kinesis/aws-kinesis-uri-binding.feature
@@ -2,7 +2,7 @@ Feature: AWS Kinesis Kamelet - binding to URI
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,24 +12,24 @@ Feature: AWS Kinesis Kamelet - binding to URI
     | aws.kinesis.command    | "create-stream", "--stream-name", "${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}", "--shard-count", "1" |
     When load Kubernetes resource aws-kinesis-client.yaml
 
-  Scenario: Create Camel-K resources
+  Scenario: Create Camel K resources
     Given Kamelet aws-kinesis-source is available
     Given load KameletBinding aws-kinesis-uri-binding.yaml
     Given KameletBinding aws-kinesis-uri-binding is available
     Given variable loginfo is "aws2-kinesis://${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}"
-    Then Camel-K integration aws-kinesis-uri-binding should print ${loginfo}
+    Then Camel K integration aws-kinesis-uri-binding should print ${loginfo}
 
   Scenario: Verify Kamelet source - binding to URI
     Given variable aws.kinesis.streamData is "abc"
     Given Camel exchange message header CamelAwsKinesisPartitionKey="${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.partitionKey}"
     Given Camel exchange body: ${aws.kinesis.streamData}
-    When Camel-K integration aws-kinesis-uri-binding is running
+    When Camel K integration aws-kinesis-uri-binding is running
     Then sleep 10000 ms
     And send Camel exchange to("aws2-kinesis:${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.stream}?accessKey=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.secretKey})&region=${camel.kamelet.aws-kinesis-source.aws-kinesis-credentials.region}")
-    Then Camel-K integration aws-kinesis-uri-binding should print "data":{"bytes":[97,98,99]
+    Then Camel K integration aws-kinesis-uri-binding should print "data":{"bytes":[97,98,99]
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-kinesis-uri-binding
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-kinesis-uri-binding
 
   Scenario: Remove AWS Kinesis data stream
     Given variables

--- a/test/aws-sqs/README.md
+++ b/test/aws-sqs/README.md
@@ -4,7 +4,7 @@ This test verifies the AWS SQS Kamelet source defined in [aws-sqs-source.kamelet
 
 ## Objectives
 
-The test verifies the AWS SQS Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for messages on the
+The test verifies the AWS SQS Kamelet source by creating a Camel K integration that uses the Kamelet and listens for messages on the
 AWS SQS channel.
 
 This test uses [aws-cli](https://github.com/aws/aws-cli) image as a test client for extecution of validation steps.
@@ -19,23 +19,23 @@ The test performs the following high level steps for configs - URI, secret and p
 
 *Scenario* 
 - Create the Kamelet in the current namespace in the cluster
-- Create the Camel-K integration that uses the Kamelet
-- Wait for the Camel-K integration to start and listen for AWS SQS messages
+- Create the Camel K integration that uses the Kamelet
+- Wait for the Camel K integration to start and listen for AWS SQS messages
 - Create a new message in the AWS SQS queue
 - Verify that the integration has received the message event
 
 *Cleanup*
-- Delete the Camel-K integration
+- Delete the Camel K integration
 - Delete the secret from the current namespacce
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/aws-sqs/aws-sqs-inmem-binding.feature
+++ b/test/aws-sqs/aws-sqs-inmem-binding.feature
@@ -2,7 +2,7 @@ Feature: AWS SQS Kamelet - binding to InMemoryChannel
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given create Knative channel messages
@@ -18,19 +18,19 @@ Feature: AWS SQS Kamelet - binding to InMemoryChannel
     Given load KameletBinding inmem-to-log.yaml
     Then KameletBinding aws-sqs-to-inmem is available
     And KameletBinding inmem-to-log should be available
-    Then Camel-K integration aws-sqs-to-inmem is running
-    And Camel-K integration inmem-to-log is running
+    Then Camel K integration aws-sqs-to-inmem is running
+    And Camel K integration inmem-to-log is running
 
-    And Camel-K integration aws-sqs-to-inmem should print Installed features
-    And Camel-K integration inmem-to-log should print Installed features
+    And Camel K integration aws-sqs-to-inmem should print Installed features
+    And Camel K integration inmem-to-log should print Installed features
     Then sleep 10000 ms
 
     Given variable aws.sqs.message is "Hello from SQS Kamelet"
     Given Camel exchange body: ${aws.sqs.message}
     And send Camel exchange to("aws2-sqs:${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}?accessKey=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-sqs-source.aws-sqs-credentials.secretKey})&region=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.region}")
-    Then Camel-K integration inmem-to-log should print "${aws.sqs.message}"
+    Then Camel K integration inmem-to-log should print "${aws.sqs.message}"
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given delete KameletBinding aws-sqs-to-inmem
     Given delete KameletBinding inmem-to-log
 

--- a/test/aws-sqs/aws-sqs-source-property-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-property-conf.feature
@@ -2,7 +2,7 @@ Feature: AWS SQS Kamelet - property based config
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,9 +12,9 @@ Feature: AWS SQS Kamelet - property based config
     | aws.sqs.command    | "create-queue", "--queue-name", "${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}" |
     When load Kubernetes resource aws-sqs-client.yaml
 
-  Scenario: Create Camel-K resources
-    Given Camel-K integration property file aws-sqs-credentials.properties
-    Given create Camel-K integration aws-sqs-to-log-prop-based.groovy
+  Scenario: Create Camel K resources
+    Given Camel K integration property file aws-sqs-credentials.properties
+    Given create Camel K integration aws-sqs-to-log-prop-based.groovy
     """
     from("kamelet:aws-sqs-source/aws-sqs-credentials")
       .to("log:info")
@@ -24,12 +24,12 @@ Feature: AWS SQS Kamelet - property based config
   Scenario: Verify Kamelet source
     Given variable aws.sqs.message is "Hello from SQS Kamelet"
     Given Camel exchange body: ${aws.sqs.message}
-    When Camel-K integration aws-sqs-to-log-prop-based is running
+    When Camel K integration aws-sqs-to-log-prop-based is running
     And send Camel exchange to("aws2-sqs:${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}?accessKey=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-sqs-source.aws-sqs-credentials.secretKey})&region=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.region}")
-    Then Camel-K integration aws-sqs-to-log-prop-based should print "${aws.sqs.message}"
+    Then Camel K integration aws-sqs-to-log-prop-based should print "${aws.sqs.message}"
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-sqs-to-log-prop-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-sqs-to-log-prop-based
 
   Scenario: Remove AWS SQS queue
     Given variables

--- a/test/aws-sqs/aws-sqs-source-secret-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-secret-conf.feature
@@ -2,7 +2,7 @@ Feature: AWS SQS Kamelet - secret based config
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,19 +12,19 @@ Feature: AWS SQS Kamelet - secret based config
     | aws.sqs.command    | "create-queue", "--queue-name", "${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}" |
     When load Kubernetes resource aws-sqs-client.yaml
 
-  Scenario: Create Camel-K resources
-    And load Camel-K integration aws-sqs-to-log-secret-based.groovy
+  Scenario: Create Camel K resources
+    And load Camel K integration aws-sqs-to-log-secret-based.groovy
     Then Kamelet aws-sqs-source is available
 
   Scenario: Verify Kamelet source
     Given variable aws.sqs.message is "Hello from SQS Kamelet"
     Given Camel exchange body: ${aws.sqs.message}
-    When Camel-K integration aws-sqs-to-log-secret-based is running
+    When Camel K integration aws-sqs-to-log-secret-based is running
     And send Camel exchange to("aws2-sqs:${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}?accessKey=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-sqs-source.aws-sqs-credentials.secretKey})&region=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.region}")
-    Then Camel-K integration aws-sqs-to-log-secret-based should print "${aws.sqs.message}"
+    Then Camel K integration aws-sqs-to-log-secret-based should print "${aws.sqs.message}"
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-sqs-to-log-secret-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-sqs-to-log-secret-based
 
   Scenario: Remove AWS SQS queue
     Given variables

--- a/test/aws-sqs/aws-sqs-source-uri-conf.feature
+++ b/test/aws-sqs/aws-sqs-source-uri-conf.feature
@@ -2,7 +2,7 @@ Feature: AWS SQS Kamelet - URI based config
 #TODO blocked by ENTESB-15094
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -14,21 +14,21 @@ Feature: AWS SQS Kamelet - URI based config
     When load Kubernetes resource aws-sqs-client.yaml
 
   @ignored
-  Scenario: Create Camel-K resources
-    And load Camel-K integration aws-sqs-to-log-uri-based.groovy
+  Scenario: Create Camel K resources
+    And load Camel K integration aws-sqs-to-log-uri-based.groovy
     Then Kamelet aws-sqs-source is available
 
   @ignored
   Scenario: Verify Kamelet source
     Given variable aws.sqs.message is "Hello from SQS Kamelet"
     Given Camel exchange body: ${aws.sqs.message}
-    When Camel-K integration aws-sqs-to-log-uri-based is running
+    When Camel K integration aws-sqs-to-log-uri-based is running
     And send Camel exchange to("aws2-sqs:${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}?accessKey=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-sqs-source.aws-sqs-credentials.secretKey})&region=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.region}")
-    Then Camel-K integration aws-sqs-to-log-uri-based should print "${aws.sqs.message}"
+    Then Camel K integration aws-sqs-to-log-uri-based should print "${aws.sqs.message}"
 
   @ignored
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration aws-sqs-to-log-uri-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration aws-sqs-to-log-uri-based
 
   @ignored
   Scenario: Remove AWS SQS queue

--- a/test/aws-sqs/aws-sqs-uri-binding.feature
+++ b/test/aws-sqs/aws-sqs-uri-binding.feature
@@ -2,7 +2,7 @@ Feature: AWS SQS Kamelet - binding to URI
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
 
@@ -12,23 +12,23 @@ Feature: AWS SQS Kamelet - binding to URI
     | aws.sqs.command    | "create-queue", "--queue-name", "${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}" |
     When load Kubernetes resource aws-sqs-client.yaml
 
-  Scenario: Create Camel-K resources
+  Scenario: Create Camel K resources
     Given Kamelet aws-sqs-source is available
     Given load KameletBinding aws-sqs-uri-binding.yaml
     Given KameletBinding aws-sqs-uri-binding is available
     Given variable loginfo is "Installed features"
-    Then Camel-K integration aws-sqs-uri-binding should print ${loginfo}
+    Then Camel K integration aws-sqs-uri-binding should print ${loginfo}
 
   Scenario: Verify Kamelet source
     Given variable aws.sqs.message is "Hello from SQS Kamelet"
     Given Camel exchange body: ${aws.sqs.message}
-    When Camel-K integration aws-sqs-uri-binding is running
+    When Camel K integration aws-sqs-uri-binding is running
     And send Camel exchange to("aws2-sqs:${camel.kamelet.aws-sqs-source.aws-sqs-credentials.queueNameOrArn}?accessKey=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.accessKey}&secretKey=RAW(${camel.kamelet.aws-sqs-source.aws-sqs-credentials.secretKey})&region=${camel.kamelet.aws-sqs-source.aws-sqs-credentials.region}")
-    Then Camel-K integration aws-sqs-uri-binding should print "${aws.sqs.message}"
+    Then Camel K integration aws-sqs-uri-binding should print "${aws.sqs.message}"
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given delete KameletBinding aws-sqs-uri-binding
-    Given delete Camel-K integration aws-sqs-uri-binding
+    Given delete Camel K integration aws-sqs-uri-binding
 
   Scenario: Remove AWS SQS queue
     Given variables

--- a/test/extract-field/README.md
+++ b/test/extract-field/README.md
@@ -17,7 +17,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the action (timer-source to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Verify that the binding has performed the Kamelet action as expected by verifying the Http service sink request data
 
 *Cleanup*
@@ -26,12 +26,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/extract-field/extract-field.feature
+++ b/test/extract-field/extract-field.feature
@@ -8,7 +8,7 @@ Feature: Extract field Kamelet action
     Given create Kubernetes service test-extract-service with target port 8080
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     Given variable field = "subject"
@@ -17,7 +17,7 @@ Feature: Extract field Kamelet action
     { "id": "citrus:randomUUID()", "subject": "Camel K rocks!" }
     """
     When load Kubernetes custom resource extract-field-test.yaml in kameletbindings.camel.apache.org
-    Then Camel-K integration extract-field-test should be running
+    Then Camel K integration extract-field-test should be running
 
   Scenario: Verify output message sent
     Given expect HTTP request body: "Camel K rocks!"

--- a/test/ftp/README.md
+++ b/test/ftp/README.md
@@ -14,12 +14,12 @@ The test itself provides a FTP server instance that can be used by the Kamelet s
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/ftp/sink/README.md
+++ b/test/ftp/sink/README.md
@@ -20,7 +20,7 @@ The test performs the following high level steps:
 
 *Scenario*
 - Configure and create the Kamelet binding that uses the sink (kafka-sink to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Verify that the binding has performed the content as expected by verifying the file content on the FTP server instance
 
 *Cleanup*
@@ -29,12 +29,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/ftp/sink/ftp-sink.feature
+++ b/test/ftp/sink/ftp-sink.feature
@@ -20,11 +20,11 @@ Feature: FTP Kamelet sink
     Given load endpoint ftp-server.groovy
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     When load Kubernetes custom resource ftp-sink-test.yaml in kameletbindings.camel.apache.org
-    Then Camel-K integration ftp-sink-test should be running
+    Then Camel K integration ftp-sink-test should be running
 
   Scenario: Verify FTP file created
     When endpoint ftp-server receives body

--- a/test/ftp/source/README.md
+++ b/test/ftp/source/README.md
@@ -20,7 +20,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the source (kafka-source to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Provide proper file content on the FTP server instance
 - Verify that the binding has performed the Kamelet source as expected by verifying the Http service sink request data
 
@@ -30,12 +30,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/ftp/source/ftp-source.feature
+++ b/test/ftp/source/ftp-source.feature
@@ -25,12 +25,12 @@ Feature: FTP Kamelet source
     Given load endpoint ftp-server.groovy
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     When load KameletBinding ftp-source-test.yaml
-    Then Camel-K integration ftp-source-test should be running
-    And Camel-K integration ftp-source-test should print Routes startup summary
+    Then Camel K integration ftp-source-test should be running
+    And Camel K integration ftp-source-test should print Routes startup summary
 
   Scenario: Create FTP file
     Given sleep 5000 ms

--- a/test/http-sink/README.md
+++ b/test/http-sink/README.md
@@ -17,7 +17,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the action (timer-source to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Verify that the binding has performed the Kamelet action as expected by verifying the Http service sink request data
 
 *Cleanup*
@@ -26,12 +26,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/http-sink/http-sink.feature
+++ b/test/http-sink/http-sink.feature
@@ -9,11 +9,11 @@ Feature: Extract field Kamelet action
     Given create Kubernetes service sink-http-service with target port 8080
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     When load KameletBinding http-sink-test.yaml
-    Then Camel-K integration http-sink-test should be running
+    Then Camel K integration http-sink-test should be running
 
   Scenario: Verify request message sent
     Given expect HTTP request body: ${message}

--- a/test/insert-field/README.md
+++ b/test/insert-field/README.md
@@ -17,7 +17,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the action (timer-source to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Verify that the binding has performed the Kamelet action as expected by verifying the Http service sink request data
 
 *Cleanup*
@@ -26,12 +26,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/insert-field/insert-field.feature
+++ b/test/insert-field/insert-field.feature
@@ -11,7 +11,7 @@ Feature: Extract field Kamelet action
     Given create Kubernetes service test-insert-service with target port 8080
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     Given variable input is
@@ -19,7 +19,7 @@ Feature: Extract field Kamelet action
     { "id": "citrus:randomUUID()" }
     """
     When load Kubernetes custom resource insert-field-test.yaml in kameletbindings.camel.apache.org
-    Then Camel-K integration insert-field-test should be running
+    Then Camel K integration insert-field-test should be running
 
   Scenario: Verify output message sent
     Given expect HTTP request body

--- a/test/jira/jira-binding.feature
+++ b/test/jira/jira-binding.feature
@@ -2,7 +2,7 @@ Feature: Jira Kamelet Binding
 
   Background:
     Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kubernetes resources
 
   Scenario: Verify resources
@@ -12,7 +12,7 @@ Feature: Jira Kamelet Binding
     Given KameletBinding jira-to-inmem is available
     Given KameletBinding inmem-to-log is available
     Given variable loginfo is "knative://channel/messages"
-    Then Camel-K integration inmem-to-log should print ${loginfo}
+    Then Camel K integration inmem-to-log should print ${loginfo}
 
   Scenario: Verify new jira issue is created
     Given variable summary is "New bug, citrus:randomString(10)"
@@ -38,15 +38,15 @@ Feature: Jira Kamelet Binding
     When send POST /rest/api/2/issue/
     Then verify HTTP response expression: $.key="@variable(key)@"
     Then receive HTTP 201 CREATED
-    And Camel-K integration inmem-to-log should print ${summary}
+    And Camel K integration inmem-to-log should print ${summary}
     Given URL: ${camel.kamelet.jira-source.jira-credentials.jiraUrl}
     And HTTP request header Authorization="Basic citrus:encodeBase64(${camel.kamelet.jira-source.jira-credentials.username}:${camel.kamelet.jira-source.jira-credentials.password})"
     And HTTP request header Content-Type="application/json"
     When send DELETE /rest/api/2/issue/${key}
     Then receive HTTP 204 NO_CONTENT
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration jira-to-inmem
-    Given delete Camel-K integration inmem-to-log
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration jira-to-inmem
+    Given delete Camel K integration inmem-to-log
     Given delete KameletBinding jira-to-inmem
     Given delete KameletBinding inmem-to-log

--- a/test/jira/jira-source-prop-based.feature
+++ b/test/jira/jira-source-prop-based.feature
@@ -2,19 +2,19 @@ Feature: Jira Kamelet - property based config
 
   Background:
     Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Kamelet jira-source is available
 
   Scenario: Verify resources
-    Given Camel-K integration property file jira-credentials.properties
-    Given create Camel-K integration jira-to-log-prop-based.groovy
+    Given Camel K integration property file jira-credentials.properties
+    Given create Camel K integration jira-to-log-prop-based.groovy
     """
     from("kamelet:jira-source/jira-credentials")
       .to('log:info')
     """
-    Given Camel-K integration jira-to-log-prop-based is running
+    Given Camel K integration jira-to-log-prop-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration jira-to-log-prop-based should print ${loginfo}
+    Then Camel K integration jira-to-log-prop-based should print ${loginfo}
 
   Scenario: Verify new jira issue is created, property based config
     Given variable summary is "New bug, citrus:randomString(10)"
@@ -40,12 +40,12 @@ Feature: Jira Kamelet - property based config
     When send POST /rest/api/2/issue/
     Then verify HTTP response expression: $.key="@variable(key)@"
     Then receive HTTP 201 CREATED
-    And Camel-K integration jira-to-log-prop-based should print ${summary}
+    And Camel K integration jira-to-log-prop-based should print ${summary}
     Given URL: ${camel.kamelet.jira-source.jira-credentials.jiraUrl}
     And HTTP request header Authorization="Basic citrus:encodeBase64(${camel.kamelet.jira-source.jira-credentials.username}:${camel.kamelet.jira-source.jira-credentials.password})"
     And HTTP request header Content-Type="application/json"
     When send DELETE /rest/api/2/issue/${key}
     Then receive HTTP 204 NO_CONTENT
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration jira-to-log-prop-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration jira-to-log-prop-based

--- a/test/jira/jira-source-secret-based.feature
+++ b/test/jira/jira-source-secret-based.feature
@@ -2,14 +2,14 @@ Feature: Jira Kamelet - secret based config
 
   Background:
     Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Kamelet jira-source is available
 
   Scenario: Verify resources, secret based config
-    Given load Camel-K integration jira-to-log-secret-based.groovy
-    Given Camel-K integration jira-to-log-secret-based is running
+    Given load Camel K integration jira-to-log-secret-based.groovy
+    Given Camel K integration jira-to-log-secret-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration jira-to-log-secret-based should print ${loginfo}
+    Then Camel K integration jira-to-log-secret-based should print ${loginfo}
 
   Scenario: Verify new jira issue is created, secret based config
     Given variable summary is "New bug, citrus:randomString(10)"
@@ -35,12 +35,12 @@ Feature: Jira Kamelet - secret based config
     When send POST /rest/api/2/issue/
     Then verify HTTP response expression: $.key="@variable(key)@"
     Then receive HTTP 201 CREATED
-    And Camel-K integration jira-to-log-secret-based should print ${summary}
+    And Camel K integration jira-to-log-secret-based should print ${summary}
     Given URL: ${camel.kamelet.jira-source.jira-credentials.jiraUrl}
     And HTTP request header Authorization="Basic citrus:encodeBase64(${camel.kamelet.jira-source.jira-credentials.username}:${camel.kamelet.jira-source.jira-credentials.password})"
     And HTTP request header Content-Type="application/json"
     When send DELETE /rest/api/2/issue/${key}
     Then receive HTTP 204 NO_CONTENT
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration jira-to-log-secret-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration jira-to-log-secret-based

--- a/test/jira/jira-source-uri-based.feature
+++ b/test/jira/jira-source-uri-based.feature
@@ -2,13 +2,13 @@ Feature: Jira Kamelet - URI based config
 
   Background:
     Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
 
   Scenario: Verify resources
-    Given load Camel-K integration jira-to-log-uri-based.groovy
-    Given Camel-K integration jira-to-log-uri-based is running
+    Given load Camel K integration jira-to-log-uri-based.groovy
+    Given Camel K integration jira-to-log-uri-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration jira-to-log-uri-based should print ${loginfo}
+    Then Camel K integration jira-to-log-uri-based should print ${loginfo}
 
   Scenario: Verify Jira Kamelet with URI based config
     Given variable summary is "New bug, citrus:randomString(10)"
@@ -34,13 +34,13 @@ Feature: Jira Kamelet - URI based config
     When send POST /rest/api/2/issue/
     Then verify HTTP response expression: $.key="@variable(key)@"
     Then receive HTTP 201 CREATED
-    And Camel-K integration jira-to-log-uri-based should print ${summary}
+    And Camel K integration jira-to-log-uri-based should print ${summary}
     Given URL: ${camel.kamelet.jira-source.jira-credentials.jiraUrl}
     And HTTP request header Authorization="Basic citrus:encodeBase64(${camel.kamelet.jira-source.jira-credentials.username}:${camel.kamelet.jira-source.jira-credentials.password})"
     And HTTP request header Content-Type="application/json"
     When send DELETE /rest/api/2/issue/${key}
     Then receive HTTP 204 NO_CONTENT
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration jira-to-log-uri-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration jira-to-log-uri-based
 

--- a/test/jira/jira-uri-binding.feature
+++ b/test/jira/jira-uri-binding.feature
@@ -2,14 +2,14 @@ Feature: Jira Kamelet - binding to URI
 
   Background:
     Given Disable auto removal of Kamelet resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Kamelet jira-source is available
 
   Scenario: Verify resources
     Given load KameletBinding jira-uri-binding.yaml
     Given KameletBinding jira-uri-binding is available
     Given variable loginfo is "Installed features"
-    Then Camel-K integration jira-uri-binding should print ${loginfo}
+    Then Camel K integration jira-uri-binding should print ${loginfo}
 
   Scenario: Verify new jira issue is created
     Given variable summary is "New bug, citrus:randomString(10)"
@@ -35,12 +35,12 @@ Feature: Jira Kamelet - binding to URI
     When send POST /rest/api/2/issue/
     Then verify HTTP response expression: $.key="@variable(key)@"
     Then receive HTTP 201 CREATED
-    And Camel-K integration jira-uri-binding should print ${summary}
+    And Camel K integration jira-uri-binding should print ${summary}
     Given URL: ${camel.kamelet.jira-source.jira-credentials.jiraUrl}
     And HTTP request header Authorization="Basic citrus:encodeBase64(${camel.kamelet.jira-source.jira-credentials.username}:${camel.kamelet.jira-source.jira-credentials.password})"
     And HTTP request header Content-Type="application/json"
     When send DELETE /rest/api/2/issue/${key}
     Then receive HTTP 204 NO_CONTENT
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration jira-uri-binding
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration jira-uri-binding

--- a/test/kafka/README.md
+++ b/test/kafka/README.md
@@ -21,7 +21,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the source (kafka-source to uri)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Send message to Kafka topic
 - Verify that the source binding has processed the Kafka message as expected by verifying the Http service sink request data
 
@@ -41,7 +41,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the sink (timer-source to kafka)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Receive and verify message on Kafka topic
 
 *Cleanup*
@@ -49,12 +49,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/kafka/kafka-sink.feature
+++ b/test/kafka/kafka-sink.feature
@@ -13,11 +13,11 @@ Feature: Kafka Kamelet sink
     Given Kafka topic partition: 0
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     When load KameletBinding kafka-sink-test.yaml
-    Then Camel-K integration kafka-sink-test should be running
+    Then Camel K integration kafka-sink-test should be running
 
   Scenario: Receive message on Kafka topic and verify sink output
     Given Kafka connection

--- a/test/kafka/kafka-source.feature
+++ b/test/kafka/kafka-source.feature
@@ -20,12 +20,12 @@ Feature: Kafka Kamelet source
     Given create Kubernetes service kafka-to-http-service with target port 8080
 
   Scenario: Create Kamelet binding
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     When load KameletBinding kafka-source-test.yaml
-    Then Camel-K integration kafka-source-test should be running
-    And Camel-K integration kafka-source-test should print Resetting offset for partition ${topic}-0
+    Then Camel K integration kafka-source-test should be running
+    And Camel K integration kafka-source-test should print Resetting offset for partition ${topic}-0
 
   Scenario: Send message to Kafka topic and verify sink output
     Given Kafka connection

--- a/test/postgresql/README.md
+++ b/test/postgresql/README.md
@@ -22,7 +22,7 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Configure and create the Kamelet binding that uses the sink (timer to postgresql sink)
-- Wait for the Camel-K integration to start
+- Wait for the Camel K integration to start
 - Query the PostgreSQL database and verify the result set
 
 *Cleanup*
@@ -31,12 +31,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/postgresql/postgresql-sink.feature
+++ b/test/postgresql/postgresql-sink.feature
@@ -19,13 +19,13 @@ Feature: PostgreSQL Kamelet sink
       | url       | ${YAKS_TESTCONTAINERS_POSTGRESQL_URL} |
       | username  | ${YAKS_TESTCONTAINERS_POSTGRESQL_USERNAME} |
       | password  | ${YAKS_TESTCONTAINERS_POSTGRESQL_PASSWORD} |
-    Given Camel-K resource polling configuration
+    Given Camel K resource polling configuration
       | maxAttempts          | 200   |
       | delayBetweenAttempts | 2000  |
     Given SQL query max retry attempts: 10
     When load KameletBinding postgresql-sink-test.yaml
-    Then Camel-K integration postgresql-sink-test should be running
-    And Camel-K integration postgresql-sink-test should print Started source (timer://tick)
+    Then Camel K integration postgresql-sink-test should be running
+    And Camel K integration postgresql-sink-test should print Started source (timer://tick)
     Then SQL query: SELECT headline FROM headlines WHERE ID=${id}
     And verify column HEADLINE=Camel K rocks!
 

--- a/test/salesforce/README.md
+++ b/test/salesforce/README.md
@@ -4,7 +4,7 @@ This test verifies the Salesforce Kamelet source defined in [salesforce-source.k
 
 ## Objectives
 
-The test verifies the Salesforce Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for Case objects on the
+The test verifies the Salesforce Kamelet source by creating a Camel K integration that uses the Kamelet and listens for Case objects on the
 Salesforce account.
 
 ### Test Kamelet source
@@ -19,13 +19,13 @@ The test performs the following high level steps:
 - Obtain an authorization token from Salesforce login
 - Obtain the account id for the Salesforce account
 - Create the Kamelet in the current namespace in the cluster
-- Create the Camel-K integration that uses the Kamelet
-- Wait for the Camel-K integration to start and listen for Case objects
+- Create the Camel K integration that uses the Kamelet
+- Wait for the Camel K integration to start and listen for Case objects
 - Create a new Case object on the Salesforce API
 - Verify that the integration has received the Case object event
 
 *Cleanup*
-- Delete the Camel-K integration
+- Delete the Camel K integration
 - Delete the secret from the current namespacce
 
 ### Test KameletBinding
@@ -53,12 +53,12 @@ The test performs the following high level steps:
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/salesforce/salesforce-binding.feature
+++ b/test/salesforce/salesforce-binding.feature
@@ -1,7 +1,7 @@
 Feature: Salesforce Kamelet binding
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable token_request is "grant_type=password&client_id=${camel.kamelet.salesforce-source.salesforce-credentials.clientId}&client_secret=${camel.kamelet.salesforce-source.salesforce-credentials.clientSecret}&username=${camel.kamelet.salesforce-source.salesforce-credentials.userName}&password=${camel.kamelet.salesforce-source.salesforce-credentials.password}"
@@ -35,9 +35,9 @@ Feature: Salesforce Kamelet binding
   Scenario: Verify Kamelet binding
     Given variable subject is "Case regarding citrus:randomString(10)"
     Given variable description is "Test for Salesforce Kamelet source"
-    Given Camel-K integration salesforce-to-uri is running
-    And Camel-K integration salesforce-to-uri should print Login successful
-    And Camel-K integration salesforce-to-uri should print Subscribed to channel /topic/CamelTestTopic
+    Given Camel K integration salesforce-to-uri is running
+    And Camel K integration salesforce-to-uri should print Login successful
+    And Camel K integration salesforce-to-uri should print Subscribed to channel /topic/CamelTestTopic
     And HTTP request header Authorization="Bearer ${access_token}"
     And HTTP request header Content-Type="application/json"
     And HTTP request body

--- a/test/salesforce/salesforce-inmem-binding.feature
+++ b/test/salesforce/salesforce-inmem-binding.feature
@@ -1,7 +1,7 @@
 Feature: Salesforce Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given create Knative channel messages
 
@@ -10,11 +10,11 @@ Feature: Salesforce Kamelet
     Given load KameletBinding salesforce-to-inmem.yaml
     Given load KameletBinding inmem-to-log.yaml
     Then KameletBinding salesforce-to-inmem should be available
-    And Camel-K integration salesforce-to-inmem is running
+    And Camel K integration salesforce-to-inmem is running
 
     And KameletBinding inmem-to-log should be available
     Given variable loginfo is "Installed features"
-    Then Camel-K integration salesforce-to-inmem should print ${loginfo}
+    Then Camel K integration salesforce-to-inmem should print ${loginfo}
     Then sleep 10000 ms
 
     #obtain token
@@ -51,8 +51,8 @@ Feature: Salesforce Kamelet
     """
     When send POST /services/data/v${camel.kamelet.salesforce-source.salesforce-credentials.apiVersion}/sobjects/Case
     Then receive HTTP 201 Created
-    And Camel-K integration inmem-to-log should print "Subject":"${subject}"
+    And Camel K integration inmem-to-log should print "Subject":"${subject}"
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given delete KameletBinding salesforce-to-broker
     Given delete KameletBinding broker-to-log

--- a/test/salesforce/salesforce-source-property-based.feature
+++ b/test/salesforce/salesforce-source-property-based.feature
@@ -1,7 +1,7 @@
 Feature: Salesforce Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given variable token_request is "grant_type=password&client_id=${camel.kamelet.salesforce-source.salesforce-credentials.clientId}&client_secret=${camel.kamelet.salesforce-source.salesforce-credentials.clientSecret}&username=${camel.kamelet.salesforce-source.salesforce-credentials.userName}&password=${camel.kamelet.salesforce-source.salesforce-credentials.password}"
     Given URL: ${camel.kamelet.salesforce-source.salesforce-credentials.loginUrl}
@@ -19,9 +19,9 @@ Feature: Salesforce Kamelet
     Then verify HTTP response expression: $.records[0].Id="@variable(account_id)@"
     And receive HTTP 200 OK
 
-  Scenario: Create Camel-K resources
-    Given Camel-K integration property file salesforce-credentials.properties
-    Given create Camel-K integration salesforce-to-log-property-based.groovy
+  Scenario: Create Camel K resources
+    Given Camel K integration property file salesforce-credentials.properties
+    Given create Camel K integration salesforce-to-log-property-based.groovy
     """
     from("kamelet:salesforce-source/salesforce-credentials")
     .to('log:info')
@@ -31,9 +31,9 @@ Feature: Salesforce Kamelet
   Scenario: Verify Kamelet source
     Given variable subject is "Case regarding citrus:randomString(10)"
     Given variable description is "Test for Salesforce Kamelet source"
-    Given Camel-K integration salesforce-to-log-property-based is running
-    And Camel-K integration salesforce-to-log-property-based should print Login successful
-    And Camel-K integration salesforce-to-log-property-based should print Subscribed to channel /topic/
+    Given Camel K integration salesforce-to-log-property-based is running
+    And Camel K integration salesforce-to-log-property-based should print Login successful
+    And Camel K integration salesforce-to-log-property-based should print Subscribed to channel /topic/
     And HTTP request header Authorization="Bearer ${access_token}"
     And HTTP request header Content-Type="application/json"
     And HTTP request body
@@ -46,7 +46,7 @@ Feature: Salesforce Kamelet
     """
     When send POST /services/data/v${camel.kamelet.salesforce-source.salesforce-credentials.apiVersion}/sobjects/Case
     Then receive HTTP 201 Created
-    And Camel-K integration salesforce-to-log-property-based should print "Subject":"${subject}"
+    And Camel K integration salesforce-to-log-property-based should print "Subject":"${subject}"
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration salesforce-to-log-property-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration salesforce-to-log-property-based

--- a/test/salesforce/salesforce-source-secret-based.feature
+++ b/test/salesforce/salesforce-source-secret-based.feature
@@ -1,7 +1,7 @@
 Feature: Salesforce Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given variable token_request is "grant_type=password&client_id=${camel.kamelet.salesforce-source.salesforce-credentials.clientId}&client_secret=${camel.kamelet.salesforce-source.salesforce-credentials.clientSecret}&username=${camel.kamelet.salesforce-source.salesforce-credentials.userName}&password=${camel.kamelet.salesforce-source.salesforce-credentials.password}"
     Given URL: ${camel.kamelet.salesforce-source.salesforce-credentials.loginUrl}
@@ -19,8 +19,8 @@ Feature: Salesforce Kamelet
     Then verify HTTP response expression: $.records[0].Id="@variable(account_id)@"
     And receive HTTP 200 OK
 
-  Scenario: Create Camel-K resources
-    Given create Camel-K integration salesforce-to-log-secret-based.groovy
+  Scenario: Create Camel K resources
+    Given create Camel K integration salesforce-to-log-secret-based.groovy
     """
     from("kamelet:salesforce-source/salesforce-credentials")
     .to('log:info')
@@ -30,9 +30,9 @@ Feature: Salesforce Kamelet
   Scenario: Verify Kamelet source
     Given variable subject is "Case regarding citrus:randomString(10)"
     Given variable description is "Test for Salesforce Kamelet source"
-    Given Camel-K integration salesforce-to-log-secret-based is running
-    And Camel-K integration salesforce-to-log-secret-based should print Login successful
-    And Camel-K integration salesforce-to-log-secret-based should print Subscribed to channel /topic/
+    Given Camel K integration salesforce-to-log-secret-based is running
+    And Camel K integration salesforce-to-log-secret-based should print Login successful
+    And Camel K integration salesforce-to-log-secret-based should print Subscribed to channel /topic/
     And HTTP request header Authorization="Bearer ${access_token}"
     And HTTP request header Content-Type="application/json"
     And HTTP request body
@@ -45,7 +45,7 @@ Feature: Salesforce Kamelet
     """
     When send POST /services/data/v${camel.kamelet.salesforce-source.salesforce-credentials.apiVersion}/sobjects/Case
     Then receive HTTP 201 Created
-    And Camel-K integration salesforce-to-log-secret-based should print "Subject":"${subject}"
+    And Camel K integration salesforce-to-log-secret-based should print "Subject":"${subject}"
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration salesforce-to-log-secret-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration salesforce-to-log-secret-based

--- a/test/salesforce/salesforce-source-uri-based.feature
+++ b/test/salesforce/salesforce-source-uri-based.feature
@@ -1,7 +1,7 @@
 Feature: Salesforce Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given variable token_request is "grant_type=password&client_id=${camel.kamelet.salesforce-source.salesforce-credentials.clientId}&client_secret=${camel.kamelet.salesforce-source.salesforce-credentials.clientSecret}&username=${camel.kamelet.salesforce-source.salesforce-credentials.userName}&password=${camel.kamelet.salesforce-source.salesforce-credentials.password}"
     Given URL: ${camel.kamelet.salesforce-source.salesforce-credentials.loginUrl}
@@ -19,16 +19,16 @@ Feature: Salesforce Kamelet
     Then verify HTTP response expression: $.records[0].Id="@variable(account_id)@"
     And receive HTTP 200 OK
 
-  Scenario: Create Camel-K resources
-    And load Camel-K integration salesforce-to-log-uri-based.groovy
+  Scenario: Create Camel K resources
+    And load Camel K integration salesforce-to-log-uri-based.groovy
     Then Kamelet salesforce-source is available
 
   Scenario: Verify Kamelet source
     Given variable subject is "Case regarding citrus:randomString(10)"
     Given variable description is "Test for Salesforce Kamelet source"
-    Given Camel-K integration salesforce-to-log-uri-based is running
-    And Camel-K integration salesforce-to-log-uri-based should print Login successful
-    And Camel-K integration salesforce-to-log-uri-based should print Subscribed to channel /topic/
+    Given Camel K integration salesforce-to-log-uri-based is running
+    And Camel K integration salesforce-to-log-uri-based should print Login successful
+    And Camel K integration salesforce-to-log-uri-based should print Subscribed to channel /topic/
     And HTTP request header Authorization="Bearer ${access_token}"
     And HTTP request header Content-Type="application/json"
     And HTTP request body
@@ -41,7 +41,7 @@ Feature: Salesforce Kamelet
     """
     When send POST /services/data/v${camel.kamelet.salesforce-source.salesforce-credentials.apiVersion}/sobjects/Case
     Then receive HTTP 201 Created
-    And Camel-K integration salesforce-to-log-uri-based should print "Subject":"${subject}"
+    And Camel K integration salesforce-to-log-uri-based should print "Subject":"${subject}"
 
-  Scenario: Remove Camel-K resources
-    Given delete Camel-K integration salesforce-to-log-uri-based
+  Scenario: Remove Camel K resources
+    Given delete Camel K integration salesforce-to-log-uri-based

--- a/test/slack/README.md
+++ b/test/slack/README.md
@@ -4,7 +4,7 @@ This test verifies the Slack Kamelet source defined in [slack-source.kamelet.yam
 
 ## Objectives
 
-The test verifies the Slack Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for messages on the
+The test verifies the Slack Kamelet source by creating a Camel K integration that uses the Kamelet and listens for messages on the
 Slack channel.
 
 ### Test Kamelet source
@@ -17,23 +17,23 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Create the Kamelet in the current namespace in the cluster
-- Create the Camel-K integration that uses the Kamelet
-- Wait for the Camel-K integration to start and listen for Slack messages
+- Create the Camel K integration that uses the Kamelet
+- Wait for the Camel K integration to start and listen for Slack messages
 - Create a new message on the Slack channel
 - Verify that the integration has received the message event
 
 *Cleanup*
-- Delete the Camel-K integration
+- Delete the Camel K integration
 - Delete the secret from the current namespacce
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/slack/slack-broker-binding.feature
+++ b/test/slack/slack-broker-binding.feature
@@ -1,7 +1,7 @@
 Feature: Slack Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given create Knative broker default
     Then Knative broker default is running
@@ -12,14 +12,14 @@ Feature: Slack Kamelet
     Given load KameletBinding slack-to-broker.yaml
 
     Then KameletBinding slack-to-broker should be available
-    And Camel-K integration slack-to-broker should print kamelet://slack-source/source
+    And Camel K integration slack-to-broker should print kamelet://slack-source/source
     And KameletBinding broker-to-log should be available
     Given variable loginfo is "knative://event/custom-type"
-    Then Camel-K integration broker-to-log should print ${loginfo}
+    Then Camel K integration broker-to-log should print ${loginfo}
 
     #Avoid sending message too early
-    And Camel-K integration slack-to-broker should print Installed features
-    And Camel-K integration broker-to-log should print Installed features
+    And Camel K integration slack-to-broker should print Installed features
+    And Camel K integration broker-to-log should print Installed features
     Then sleep 10000 ms
 
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -35,8 +35,8 @@ Feature: Slack Kamelet
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration broker-to-log should print ${message}
+    And Camel K integration broker-to-log should print ${message}
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given delete KameletBinding broker-to-log
     Given delete KameletBinding slack-to-broker

--- a/test/slack/slack-inmem-binding.feature
+++ b/test/slack/slack-inmem-binding.feature
@@ -1,7 +1,7 @@
 Feature: Slack Kamelet
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given create Knative channel messages
 
@@ -10,11 +10,11 @@ Feature: Slack Kamelet
     Given load KameletBinding inmem-to-log.yaml
     And KameletBinding inmem-to-log should be available
     Given variable loginfo is "knative://channel/messages"
-    Then Camel-K integration inmem-to-log should print ${loginfo}
+    Then Camel K integration inmem-to-log should print ${loginfo}
 
     Given load KameletBinding slack-to-inmem.yaml
     Then KameletBinding slack-to-inmem should be available
-    And Camel-K integration slack-to-inmem should print Installed features
+    And Camel K integration slack-to-inmem should print Installed features
 
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
     Given URL: https://slack.com
@@ -29,9 +29,9 @@ Feature: Slack Kamelet
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration inmem-to-log should print ${message}
+    And Camel K integration inmem-to-log should print ${message}
 
-  Scenario: Remove Camel-K resources
+  Scenario: Remove Camel K resources
     Given delete KameletBinding inmem-to-log
     Given delete KameletBinding slack-to-inmem
     #NOTE: InMemoryChannel is autoremoved

--- a/test/slack/slack-source-prop-based.feature
+++ b/test/slack/slack-source-prop-based.feature
@@ -1,19 +1,19 @@
 Feature: Slack Kamelet - property based configuration
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
 
-  Scenario: Create Camel-K resources
-    Given Camel-K integration property file slack-credentials.properties
-    Given create Camel-K integration slack-to-log-prop-based.groovy
+  Scenario: Create Camel K resources
+    Given Camel K integration property file slack-credentials.properties
+    Given create Camel K integration slack-to-log-prop-based.groovy
     """
     from("kamelet:slack-source/slack-credentials")
     .to('log:info')
     """
-    Given Camel-K integration slack-to-log-prop-based is running
+    Given Camel K integration slack-to-log-prop-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration slack-to-log-prop-based should print ${loginfo}
+    Then Camel K integration slack-to-log-prop-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - property based configuration
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -29,9 +29,9 @@ Feature: Slack Kamelet - property based configuration
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration slack-to-log-prop-based should print ${message}
+    And Camel K integration slack-to-log-prop-based should print ${message}
 
-  Scenario: Remove Camel-K resources - property based configuration
-    Given delete Camel-K integration slack-to-log-prop-based
+  Scenario: Remove Camel K resources - property based configuration
+    Given delete Camel K integration slack-to-log-prop-based
 
 

--- a/test/slack/slack-source-secret-based.feature
+++ b/test/slack/slack-source-secret-based.feature
@@ -1,18 +1,18 @@
 Feature: Slack Kamelet - secret based configuration
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
 
-  Scenario: Create Camel-K resources
-    Given create Camel-K integration slack-to-log-secret-based.groovy
+  Scenario: Create Camel K resources
+    Given create Camel K integration slack-to-log-secret-based.groovy
     """
     from("kamelet:slack-source/slack-credentials")
     .to('log:info')
     """
-    Given Camel-K integration slack-to-log-secret-based is running
+    Given Camel K integration slack-to-log-secret-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration slack-to-log-secret-based should print ${loginfo}
+    Then Camel K integration slack-to-log-secret-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - secret based configuration
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -28,7 +28,7 @@ Feature: Slack Kamelet - secret based configuration
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration slack-to-log-secret-based should print ${message}
+    And Camel K integration slack-to-log-secret-based should print ${message}
 
-  Scenario: Remove Camel-K resources  - secret based configuration
-    Given delete Camel-K integration slack-to-log-secret-based
+  Scenario: Remove Camel K resources  - secret based configuration
+    Given delete Camel K integration slack-to-log-secret-based

--- a/test/slack/slack-source-uri-based.feature
+++ b/test/slack/slack-source-uri-based.feature
@@ -1,14 +1,14 @@
 Feature: Slack Kamelet - URI based configuration
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
 
-  Scenario: Create Camel-K resources
-    Given load Camel-K integration slack-to-log-uri-based.groovy
-    Given Camel-K integration slack-to-log-uri-based is running
+  Scenario: Create Camel K resources
+    Given load Camel K integration slack-to-log-uri-based.groovy
+    Given Camel K integration slack-to-log-uri-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration slack-to-log-uri-based should print ${loginfo}
+    Then Camel K integration slack-to-log-uri-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - URI based configuration
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -24,7 +24,7 @@ Feature: Slack Kamelet - URI based configuration
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration slack-to-log-uri-based should print ${message}
+    And Camel K integration slack-to-log-uri-based should print ${message}
 
-  Scenario: Remove Camel-K resources - URI based configuration
-    Given delete Camel-K integration slack-to-log-uri-based
+  Scenario: Remove Camel K resources - URI based configuration
+    Given delete Camel K integration slack-to-log-uri-based

--- a/test/slack/slack-uri-binding.feature
+++ b/test/slack/slack-uri-binding.feature
@@ -1,14 +1,14 @@
 Feature: Slack Kamelet - secret based configuration
 
   Background:
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
 
-  Scenario: Create Camel-K resources
+  Scenario: Create Camel K resources
     Given load KameletBinding slack-uri-binding.yaml
     Given KameletBinding slack-uri-binding is available
     Given variable loginfo is "Installed features"
-    Then Camel-K integration slack-uri-binding should print ${loginfo}
+    Then Camel K integration slack-uri-binding should print ${loginfo}
 
   Scenario: Verify Kamelet source - secret based configuration
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -24,7 +24,7 @@ Feature: Slack Kamelet - secret based configuration
     """
     When send POST /api/chat.postMessage
     Then receive HTTP 200 OK
-    And Camel-K integration slack-uri-binding should print ${message}
+    And Camel K integration slack-uri-binding should print ${message}
 
-  Scenario: Remove Camel-K resources  - secret based configuration
-    Given delete Camel-K integration slack-uri-binding
+  Scenario: Remove Camel K resources  - secret based configuration
+    Given delete Camel K integration slack-uri-binding

--- a/test/telegram/README.md
+++ b/test/telegram/README.md
@@ -4,7 +4,7 @@ This test verifies the Telegram Kamelet source defined in [telegram-source.kamel
 
 ## Objectives
 
-The test verifies the Telegram Kamelet source by creating a Camel-K integration that uses the Kamelet and listens for messages on the
+The test verifies the Telegram Kamelet source by creating a Camel K integration that uses the Kamelet and listens for messages on the
 Telegram chat.
 
 ### Test Kamelet source
@@ -17,23 +17,23 @@ The test performs the following high level steps:
 
 *Scenario* 
 - Create the Kamelet in the current namespace in the cluster
-- Create the Camel-K integration that uses the Kamelet
-- Wait for the Camel-K integration to start and listen for Telegram chat messages
+- Create the Camel K integration that uses the Kamelet
+- Wait for the Camel K integration to start and listen for Telegram chat messages
 - Create a new message on the Telegram chat
 - Verify that the integration has received the message event
 
 *Cleanup*
-- Delete the Camel-K integration
+- Delete the Camel K integration
 - Delete the secret from the current namespace
 
 ## Installation
 
-The test assumes that you have access to a Kubernetes cluster and that the Camel-K operator as well as the YAKS operator is installed
+The test assumes that you have access to a Kubernetes cluster and that the Camel K operator as well as the YAKS operator is installed
 and running.
 
 You can review the installation steps for the operators in the documentation:
 
-- [Install Camel-K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
+- [Install Camel K operator](https://camel.apache.org/camel-k/latest/installation/installation.html)
 - [Install YAKS operator](https://github.com/citrusframework/yaks#installation)
 
 ## Preparations

--- a/test/telegram/telegram-inmem-binding.feature
+++ b/test/telegram/telegram-inmem-binding.feature
@@ -2,7 +2,7 @@ Feature: Telegram Kamelet - binding to InMemoryChannel
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
@@ -12,20 +12,20 @@ Feature: Telegram Kamelet - binding to InMemoryChannel
     Given Kamelet telegram-source is available
     Given load KameletBinding inmem-to-log.yaml
     Given load KameletBinding telegram-to-inmem.yaml
-    Given Camel-K integration telegram-to-inmem is running
+    Given Camel K integration telegram-to-inmem is running
 
     And KameletBinding inmem-to-log should be available
     Given variable loginfo is "Installed features"
-    Then Camel-K integration inmem-to-log should print ${loginfo}
-    Then Camel-K integration telegram-to-inmem should print ${loginfo}
+    Then Camel K integration inmem-to-log should print ${loginfo}
+    Then Camel K integration telegram-to-inmem should print ${loginfo}
 
-    When Camel-K integration telegram-to-inmem is running
+    When Camel K integration telegram-to-inmem is running
     And load Kubernetes resource telegram-client.yaml
-    And Camel-K integration inmem-to-log should print "${message}"
+    And Camel K integration inmem-to-log should print "${message}"
 
     Then sleep 10000 ms
 
-  Scenario: Remove Camel-K, Kubernetes resources
+  Scenario: Remove Camel K, Kubernetes resources
     Given delete KameletBinding telegram-to-inmem
     Given delete KameletBinding inmem-to-log
     Given delete Kubernetes resource telegram-client.yaml

--- a/test/telegram/telegram-source-prop-based.feature
+++ b/test/telegram/telegram-source-prop-based.feature
@@ -2,29 +2,29 @@ Feature: Telegram Kamelet - property based configuration
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
 
-  Scenario: Create Camel-K resources
-    Given Camel-K integration property file telegram-credentials.properties
+  Scenario: Create Camel K resources
+    Given Camel K integration property file telegram-credentials.properties
     Then Kamelet telegram-source is available
-    Given create Camel-K integration telegram-to-log-prop-based.groovy
+    Given create Camel K integration telegram-to-log-prop-based.groovy
     """
     from("kamelet:telegram-source/telegram-credentials")
       .to('log:info')
     """
-    Given Camel-K integration telegram-to-log-prop-based is running
+    Given Camel K integration telegram-to-log-prop-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration telegram-to-log-prop-based should print ${loginfo}
+    Then Camel K integration telegram-to-log-prop-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - property based configuration
-    When Camel-K integration telegram-to-log-prop-based is running
+    When Camel K integration telegram-to-log-prop-based is running
     And load Kubernetes resource telegram-client.yaml
-    Then Camel-K integration telegram-to-log-prop-based should print "${message}"
+    Then Camel K integration telegram-to-log-prop-based should print "${message}"
 
-  Scenario: Remove Camel-K resources - property based configuration
-    Given delete Camel-K integration telegram-to-log-prop-based
+  Scenario: Remove Camel K resources - property based configuration
+    Given delete Camel K integration telegram-to-log-prop-based
     Given delete Kubernetes resource telegram-client.yaml
 

--- a/test/telegram/telegram-source-secret-based.feature
+++ b/test/telegram/telegram-source-secret-based.feature
@@ -2,27 +2,27 @@ Feature: Telegram Kamelet - secret based configuration
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
 
-  Scenario: Create Camel-K resources
+  Scenario: Create Camel K resources
     Given Kamelet telegram-source is available
-    Given create Camel-K integration telegram-to-log-secret-based.groovy
+    Given create Camel K integration telegram-to-log-secret-based.groovy
     """
     from("kamelet:telegram-source/telegram-credentials")
     .to('log:info')
     """
-    Given Camel-K integration telegram-to-log-secret-based is running
+    Given Camel K integration telegram-to-log-secret-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration telegram-to-log-secret-based should print ${loginfo}
+    Then Camel K integration telegram-to-log-secret-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - secret based configuration
-    When Camel-K integration telegram-to-log-secret-based is running
+    When Camel K integration telegram-to-log-secret-based is running
     And load Kubernetes resource telegram-client.yaml
-    And Camel-K integration telegram-to-log-secret-based should print "${message}"
+    And Camel K integration telegram-to-log-secret-based should print "${message}"
 
-  Scenario: Remove Camel-K, Kubernetes resources - secret based configuration
-    Given delete Camel-K integration telegram-to-log-secret-based
+  Scenario: Remove Camel K, Kubernetes resources - secret based configuration
+    Given delete Camel K integration telegram-to-log-secret-based
     Given delete Kubernetes resource telegram-client.yaml

--- a/test/telegram/telegram-source-uri-based.feature
+++ b/test/telegram/telegram-source-uri-based.feature
@@ -2,23 +2,23 @@ Feature: Telegram Kamelet - URI based config
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
 
-  Scenario: Create Camel-K resources
-    When load Camel-K integration telegram-to-log-uri-based.groovy
+  Scenario: Create Camel K resources
+    When load Camel K integration telegram-to-log-uri-based.groovy
     Then Kamelet telegram-source is available
-    Given Camel-K integration telegram-to-log-uri-based is running
+    Given Camel K integration telegram-to-log-uri-based is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration telegram-to-log-uri-based should print ${loginfo}
+    Then Camel K integration telegram-to-log-uri-based should print ${loginfo}
 
   Scenario: Verify Kamelet source - URI based config
-    When Camel-K integration telegram-to-log-uri-based is running
+    When Camel K integration telegram-to-log-uri-based is running
     And load Kubernetes resource telegram-client.yaml
-    Then Camel-K integration telegram-to-log-uri-based should print "${message}"
+    Then Camel K integration telegram-to-log-uri-based should print "${message}"
 
-  Scenario: Remove Camel-K resources - URI based config
-    Given delete Camel-K integration telegram-to-log-uri-based
+  Scenario: Remove Camel K resources - URI based config
+    Given delete Camel K integration telegram-to-log-uri-based
     Given delete Kubernetes resource telegram-client.yaml

--- a/test/telegram/telegram-uri-binding.feature
+++ b/test/telegram/telegram-uri-binding.feature
@@ -2,23 +2,23 @@ Feature: Telegram Kamelet - binding to URI
 
   Background:
     Given Disable auto removal of Camel resources
-    Given Disable auto removal of Camel-K resources
+    Given Disable auto removal of Camel K resources
     Given Disable auto removal of Kamelet resources
     Given Disable auto removal of Kubernetes resources
     Given variable message is "Hello from Kamelet source citrus:randomString(10)"
 
-  Scenario: Create Camel-K resources
+  Scenario: Create Camel K resources
     Given Kamelet telegram-source is available
     Given load KameletBinding telegram-uri-binding.yaml
-    Given Camel-K integration telegram-uri-binding is running
+    Given Camel K integration telegram-uri-binding is running
     Given variable loginfo is "Installed features"
-    Then Camel-K integration telegram-uri-binding should print ${loginfo}
+    Then Camel K integration telegram-uri-binding should print ${loginfo}
 
   Scenario: Verify Kamelet source - binding to URI
-    When Camel-K integration telegram-uri-binding is running
+    When Camel K integration telegram-uri-binding is running
     And load Kubernetes resource telegram-client.yaml
-    And Camel-K integration telegram-uri-binding should print "${message}"
+    And Camel K integration telegram-uri-binding should print "${message}"
 
-  Scenario: Remove Camel-K, Kubernetes resources
-    Given delete Camel-K integration telegram-uri-binding
+  Scenario: Remove Camel K, Kubernetes resources
+    Given delete Camel K integration telegram-uri-binding
     Given delete Kubernetes resource telegram-client.yaml


### PR DESCRIPTION
Manual backport main --> kamelet-catalog-1.6

- Latest YAKS version uses official spelling of Camel K
- Use 0.9.0-202202040021 to reflect the latest updates and enhancements