### PR TITLE
chore(ci): skip catalog Kamelets installation

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -80,6 +80,8 @@ jobs:
           export KAMEL_INSTALL_BUILD_PUBLISH_STRATEGY=Spectrum
           export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
           export KAMEL_INSTALL_REGISTRY_INSECURE=true
+          # Skip the default catalog installation
+          export KAMEL_INSTALL_DEFAULT_KAMELETS=false
 
           kamel install
       - name: YAKS tools


### PR DESCRIPTION
We want to install and test the local Kamelets, not the default provided during the installation.