### PR TITLE
Fix IBM MQ Kamelets

### DIFF
--- a/docs/modules/ROOT/pages/jms-ibm-mq-sink.adoc
+++ b/docs/modules/ROOT/pages/jms-ibm-mq-sink.adoc
@@ -17,7 +17,7 @@ The following table summarizes the configuration options available for the `jms-
 | *password {empty}* *| Password| Password to authenticate to IBM MQ server| string| | 
 | *queueManager {empty}* *| IBM MQ Queue Manager| Name of the IBM MQ Queue Manager| string| | 
 | *serverName {empty}* *| IBM MQ Server name| IBM MQ Server name or address| string| | 
-| *serverPort {empty}* *| IBM MQ Server Port| IBM MQ Server port| integer| | `1414`
+| *serverPort {empty}* *| IBM MQ Server Port| IBM MQ Server port| integer| `1414`| 
 | *username {empty}* *| Username| Username to authenticate to IBM MQ server| string| | 
 | clientId| IBM MQ Client ID| Name of the IBM MQ Client ID| string| | 
 | destinationType| Destination Type| The JMS destination type (queue or topic)| string| `"queue"`| 
@@ -93,7 +93,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind channel:mychannel jms-ibm-mq-sink -p "sink.channel=The IBM MQ Channel" -p "sink.destinationName=The Destination Name" -p "sink.password=The Password" -p "sink.queueManager=The IBM MQ Queue Manager" -p "sink.serverName=The IBM MQ Server name" -p sink.serverPort=1414 -p "sink.username=The Username"
+kamel bind channel:mychannel jms-ibm-mq-sink -p "sink.channel=The IBM MQ Channel" -p "sink.destinationName=The Destination Name" -p "sink.password=The Password" -p "sink.queueManager=The IBM MQ Queue Manager" -p "sink.serverName=The IBM MQ Server name" -p "sink.username=The Username"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -154,7 +154,7 @@ Configure and run the sink by using the following command:
 
 [source,shell]
 ----
-kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic jms-ibm-mq-sink -p "sink.channel=The IBM MQ Channel" -p "sink.destinationName=The Destination Name" -p "sink.password=The Password" -p "sink.queueManager=The IBM MQ Queue Manager" -p "sink.serverName=The IBM MQ Server name" -p sink.serverPort=1414 -p "sink.username=The Username"
+kamel bind kafka.strimzi.io/v1beta1:KafkaTopic:my-topic jms-ibm-mq-sink -p "sink.channel=The IBM MQ Channel" -p "sink.destinationName=The Destination Name" -p "sink.password=The Password" -p "sink.queueManager=The IBM MQ Queue Manager" -p "sink.serverName=The IBM MQ Server name" -p "sink.username=The Username"
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/docs/modules/ROOT/pages/jms-ibm-mq-source.adoc
+++ b/docs/modules/ROOT/pages/jms-ibm-mq-source.adoc
@@ -17,7 +17,7 @@ The following table summarizes the configuration options available for the `jms-
 | *password {empty}* *| Password| Password to authenticate to IBM MQ server| string| | 
 | *queueManager {empty}* *| IBM MQ Queue Manager| Name of the IBM MQ Queue Manager| string| | 
 | *serverName {empty}* *| IBM MQ Server name| IBM MQ Server name or address| string| | 
-| *serverPort {empty}* *| IBM MQ Server Port| IBM MQ Server port| integer| | `1414`
+| *serverPort {empty}* *| IBM MQ Server Port| IBM MQ Server port| integer| `1414`| 
 | *username {empty}* *| Username| Username to authenticate to IBM MQ server| string| | 
 | clientId| IBM MQ Client ID| Name of the IBM MQ Client ID| string| | 
 | destinationType| Destination Type| The JMS destination type (queue or topic)| string| `"queue"`| 
@@ -69,7 +69,6 @@ spec:
       kind: Channel
       apiVersion: messaging.knative.dev/v1
       name: mychannel
-  
 
 ----
 
@@ -94,7 +93,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind jms-ibm-mq-source -p "source.channel=The IBM MQ Channel" -p "source.destinationName=The Destination Name" -p "source.password=The Password" -p "source.queueManager=The IBM MQ Queue Manager" -p "source.serverName=The IBM MQ Server name" -p source.serverPort=1414 -p "source.username=The Username" channel:mychannel
+kamel bind jms-ibm-mq-source -p "source.channel=The IBM MQ Channel" -p "source.destinationName=The Destination Name" -p "source.password=The Password" -p "source.queueManager=The IBM MQ Queue Manager" -p "source.serverName=The IBM MQ Server name" -p "source.username=The Username" channel:mychannel
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.
@@ -130,7 +129,6 @@ spec:
       kind: KafkaTopic
       apiVersion: kafka.strimzi.io/v1beta1
       name: my-topic
-  
 
 ----
 
@@ -156,7 +154,7 @@ Configure and run the source by using the following command:
 
 [source,shell]
 ----
-kamel bind jms-ibm-mq-source -p "source.channel=The IBM MQ Channel" -p "source.destinationName=The Destination Name" -p "source.password=The Password" -p "source.queueManager=The IBM MQ Queue Manager" -p "source.serverName=The IBM MQ Server name" -p source.serverPort=1414 -p "source.username=The Username" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
+kamel bind jms-ibm-mq-source -p "source.channel=The IBM MQ Channel" -p "source.destinationName=The Destination Name" -p "source.password=The Password" -p "source.queueManager=The IBM MQ Queue Manager" -p "source.serverName=The IBM MQ Server name" -p "source.username=The Username" kafka.strimzi.io/v1beta1:KafkaTopic:my-topic
 ----
 
 This command creates the KameletBinding in the current namespace on the cluster.

--- a/jms-ibm-mq-sink.kamelet.yaml
+++ b/jms-ibm-mq-sink.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -75,7 +75,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/jms-ibm-mq-source.kamelet.yaml
+++ b/jms-ibm-mq-source.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -75,7 +75,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-ibm-mq-sink.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -75,7 +75,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/jms-ibm-mq-source.kamelet.yaml
@@ -34,7 +34,7 @@ spec:
         title: "IBM MQ Server Port"
         description: "IBM MQ Server port"
         type: integer
-        example: 1414
+        default: 1414
       destinationType:
         title: "Destination Type"
         description: "The JMS destination type (queue or topic)"
@@ -75,7 +75,7 @@ spec:
   template:
     beans:
       - name: wmqConnectionFactory
-        type: "#class:com.ibm.mq.jms.MQQueueConnectionFactory"
+        type: "#class:com.ibm.mq.jms.MQConnectionFactory"
         property:
           - key: XMSC_WMQ_HOST_NAME
             value: '{{serverName}}'

--- a/templates/bindings/core/jms-ibm-mq-sink-binding.yaml
+++ b/templates/bindings/core/jms-ibm-mq-sink-binding.yaml
@@ -8,7 +8,7 @@
       - to:
           uri: "kamelet:jms-ibm-mq-sink"
           parameters:
-            serverName: "10.103.41.245"
+            serverName: "10.105.157.79"
             serverPort: "1414"
             destinationType: "queue"
             destinationName: "DEV.QUEUE.1"

--- a/templates/bindings/core/jms-ibm-mq-source-binding.yaml
+++ b/templates/bindings/core/jms-ibm-mq-source-binding.yaml
@@ -2,7 +2,7 @@
     from:
       uri: "kamelet:jms-ibm-mq-source"
       parameters:
-        serverName: "10.103.41.245"
+        serverName: "10.105.157.79"
         serverPort: "1414"
         destinationType: "queue"
         destinationName: "DEV.QUEUE.1"


### PR DESCRIPTION
* Currently it uses MQQueueConnectionFactory, which is specific for Queues. It should use MQConnectionFactory, which can be used for queues and topics.
* Add a default property `serverPort: 1414`

Related to ENTESB-16301