### PR TITLE
fix: bind copy-resource to proper phase

### DIFF
--- a/library/camel-kamelets-catalog/pom.xml
+++ b/library/camel-kamelets-catalog/pom.xml
@@ -102,7 +102,7 @@
                 <executions>
                     <execution>
                         <id>copy-resource-one</id>
-                        <phase>install</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>


### PR DESCRIPTION
Binding `copy-resources` to validate phase in order to have the resource copied before being packaged.