### PR TITLE
[ENTESB-19536] Replaced unmarshalTypeName, header-name in action kamelets

### DIFF
--- a/avro-deserialize-action.kamelet.yaml
+++ b/avro-deserialize-action.kamelet.yaml
@@ -47,11 +47,11 @@ spec:
       - unmarshal:
           avro:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightAvroSchemaResolver"
       - remove-property:
           property-name: schema
       - remove-property:
           property-name: validate
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/avro-serialize-action.kamelet.yaml
+++ b/avro-serialize-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
       - marshal:
           avro:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightAvroSchemaResolver"
       - remove-property:
           property-name: schema

--- a/extract-field-action.kamelet.yaml
+++ b/extract-field-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -52,7 +52,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/hoist-field-action.kamelet.yaml
+++ b/hoist-field-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -45,7 +45,7 @@ spec:
       - marshal:
           json:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/insert-field-action.kamelet.yaml
+++ b/insert-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -60,7 +60,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/json-deserialize-action.kamelet.yaml
+++ b/json-deserialize-action.kamelet.yaml
@@ -25,6 +25,6 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/json-serialize-action.kamelet.yaml
+++ b/json-serialize-action.kamelet.yaml
@@ -25,7 +25,7 @@ spec:
       - marshal:
           json: 
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-deserialize-action.kamelet.yaml
@@ -47,11 +47,11 @@ spec:
       - unmarshal:
           avro:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightAvroSchemaResolver"
       - remove-property:
           property-name: schema
       - remove-property:
           property-name: validate
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/avro-serialize-action.kamelet.yaml
@@ -47,7 +47,7 @@ spec:
       - marshal:
           avro:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightAvroSchemaResolver"
       - remove-property:
           property-name: schema

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/extract-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/extract-field-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -52,7 +52,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/hoist-field-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -45,7 +45,7 @@ spec:
       - marshal:
           json:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/insert-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "field"
           constant: "{{field}}"
@@ -60,7 +60,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/json-deserialize-action.kamelet.yaml
@@ -25,6 +25,6 @@ spec:
       - unmarshal:
           json: 
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/json-serialize-action.kamelet.yaml
@@ -25,7 +25,7 @@ spec:
       - marshal:
           json: 
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/mask-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/mask-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "fields"
           constant: "{{fields}}"
@@ -60,7 +60,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/message-timestamp-router-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "topicFormat"
           constant: "{{topicFormat}}"
@@ -69,7 +69,7 @@ spec:
       - marshal:
           json:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-deserialize-action.kamelet.yaml
@@ -37,9 +37,9 @@ spec:
       - unmarshal:
           protobuf:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightProtobufSchemaResolver"
       - remove-property:
           property-name: schema
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/protobuf-serialize-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
       - marshal:
           protobuf:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightProtobufSchemaResolver"
       - remove-property:
           property-name: schema

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/replace-field-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/replace-field-action.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "enabled"
           constant: "{{enabled}}"
@@ -69,7 +69,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/value-to-key-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "fields"
           constant: "{{fields}}"
@@ -52,7 +52,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/mask-field-action.kamelet.yaml
+++ b/mask-field-action.kamelet.yaml
@@ -45,7 +45,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "fields"
           constant: "{{fields}}"
@@ -60,7 +60,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/message-timestamp-router-action.kamelet.yaml
+++ b/message-timestamp-router-action.kamelet.yaml
@@ -52,7 +52,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "topicFormat"
           constant: "{{topicFormat}}"
@@ -69,7 +69,7 @@ spec:
       - marshal:
           json:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-header:
           name: "Content-Type"
           constant: "application/json"

--- a/protobuf-deserialize-action.kamelet.yaml
+++ b/protobuf-deserialize-action.kamelet.yaml
@@ -37,9 +37,9 @@ spec:
       - unmarshal:
           protobuf:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightProtobufSchemaResolver"
       - remove-property:
           property-name: schema
       - remove-header:
-          header-name: "Content-Type"
+          name: "Content-Type"

--- a/protobuf-serialize-action.kamelet.yaml
+++ b/protobuf-serialize-action.kamelet.yaml
@@ -37,7 +37,7 @@ spec:
       - marshal:
           protobuf:
             library: Jackson
-            unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+            unmarshalType: com.fasterxml.jackson.databind.JsonNode
             schemaResolver: "#class:org.apache.camel.kamelets.utils.serialization.InflightProtobufSchemaResolver"
       - remove-property:
           property-name: schema

--- a/replace-field-action.kamelet.yaml
+++ b/replace-field-action.kamelet.yaml
@@ -51,7 +51,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "enabled"
           constant: "{{enabled}}"
@@ -69,7 +69,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"

--- a/value-to-key-action.kamelet.yaml
+++ b/value-to-key-action.kamelet.yaml
@@ -40,7 +40,7 @@ spec:
             - unmarshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
       - set-property:
           name: "fields"
           constant: "{{fields}}"
@@ -52,7 +52,7 @@ spec:
             - marshal:
                 json:
                   library: Jackson
-                  unmarshalTypeName: com.fasterxml.jackson.databind.JsonNode
+                  unmarshalType: com.fasterxml.jackson.databind.JsonNode
             - set-header:
                 name: "Content-Type"
                 constant: "application/json"


### PR DESCRIPTION
Replaced `unmarshalTypeName` by `unmarshalType`, `remove-header:` `header-name:` by `name:` in main directory and in library/camel-kamelets-catalog/src/main/resources/kamelets/ as specified in ENTESB-19536.
@squakez FYI