### PR TITLE
CMLK-1552 Excludes unwanted snappy-java version from transitive kafka-clients and sets the desired version

### DIFF
--- a/library/camel-kamelets-utils/pom.xml
+++ b/library/camel-kamelets-utils/pom.xml
@@ -74,6 +74,18 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-kafka</artifactId>
             <version>${camel-quarkus.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy-java.version}</version>
         </dependency>
 
         <!-- AWS Dynamo DB camel component -->

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <commons.io.version>2.11.0</commons.io.version>
         <junit.jupiter.version>5.8.1</junit.jupiter.version>
         <classgraph.version>4.8.138</classgraph.version>
+        <!-- camel-quarkus-kafka brings an outdated version, so we have to fix it -->
+        <snappy-java.version>1.1.10.5</snappy-java.version>
 
         <!-- Versions used inside Kamelets (add them also to the dependencyManagement section and the groovy script below) -->
         <!-- These properties must keep this same format "version.<groupId>.<artifactId>" -->


### PR DESCRIPTION
[CMLK-1552](https://issues.redhat.com/browse/CMLK-1552)
Camel K (camel-k-1.10.5 : CK6) CVE backlog verification