### PR TITLE
update quarkus platform to 3.2.11 / camel to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.0</version>
     </parent>
 
     <groupId>org.apache.camel.kamelets</groupId>
@@ -55,11 +55,11 @@
         <maven-checksum-maven-plugin.version>1.11</maven-checksum-maven-plugin.version>
 
         <!-- don't forget to change the version in the parent declaration -->
-        <camel.version>4.0.3</camel.version>
+        <camel.version>4.0.0</camel.version>
         <camel.k.crd.version>2.2.0</camel.k.crd.version>
         <quarkus-platform-group>com.redhat.quarkus.platform</quarkus-platform-group>
         <!-- quarkus-camel-bom must drive the CEQ version, maintain the same version as in camel-k-runtime -->
-        <quarkus-platform-version>3.2.10.Final</quarkus-platform-version>
+        <quarkus-platform-version>3.2.11.Final</quarkus-platform-version>
 
         <!-- Versions used inside Kamelets (add them also to the dependencyManagement section and the groovy script below) -->
         <!-- These properties must keep this same format "version.<groupId>.<artifactId>" -->


### PR DESCRIPTION
The camel downgrade to 4.0.0, as this the productized version from CEQ and Quarkus