### PR TITLE
CMLK-1907: Fix AWS DDB Streams Source Kamelet

### DIFF
--- a/aws-ddb-streams-source.kamelet.yaml
+++ b/aws-ddb-streams-source.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
         enum: ["ap-south-1", "eu-south-1", "us-gov-east-1", "me-central-1", "ca-central-1", "eu-central-1", "us-iso-west-1", "us-west-1", "us-west-2", "af-south-1", "eu-north-1", "eu-west-3", "eu-west-2", "eu-west-1", "ap-northeast-3", "ap-northeast-2", "ap-northeast-1", "me-south-1", "sa-east-1", "ap-east-1", "cn-north-1", "us-gov-west-1", "ap-southeast-1", "ap-southeast-2", "us-iso-east-1", "ap-southeast-3", "us-east-1", "us-east-2", "cn-northwest-1", "us-isob-east-1", "aws-global", "aws-cn-global", "aws-us-gov-global", "aws-iso-global", "aws-iso-b-global"]
       streamIteratorType:
         title: Stream Iterator Type
-        description: Defines where in the DynamoDB stream to start getting records. There are two enums and the value can be one of FROM_LATEST and FROM_START. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time. 
+        description: Defines where in the DynamoDB stream to start getting records. There are two enums and the value can be one of FROM_LATEST and FROM_START. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time.
         type: string
         default: FROM_LATEST
       useDefaultCredentialsProvider:
@@ -95,10 +95,52 @@ spec:
         description: The number of milliseconds before the next poll from the database.
         type: integer
         default: 500
-  types:
+  dataTypes:
     out:
-      mediaType: application/json
+      default: json
+      headers:
+        CamelAwsDdbStreamEventSource:
+          title: The DDB Stream Event Source
+          description: The Amazon Web Services service from which the stream record originated. For DynamoDB Streams, this is aws:dynamodb.
+          type: string
+        CamelAwsDdbStreamEventId:
+          title: The DDB Stream Event Id
+          description: A globally unique identifier for the event that was recorded in this stream record.
+          type: string
+      types:
+        json:
+          format: "application-json"
+          description: Default Json representation of a DDB Stream Event.
+          mediaType: application/json
+        cloudevents:
+          format: "aws2-ddbstream:application-cloudevents"
+          description: |-
+            Data type transformer converts AWS Dynamo DB Streams get records response to CloudEvent v1_0 data format. The data
+            type sets Camel specific CloudEvent headers with values extracted from AWS Dynamo DB Streams get records.
+          headers:
+            CamelCloudEventID:
+              title: CloudEvent ID
+              description: The Camel exchange id set as event id
+              type: string
+            CamelCloudEventType:
+              title: CloudEvent Type
+              description: The event type
+              default: "org.apache.camel.event.aws.ddbstream.getRecords"
+              type: string
+            CamelCloudEventSource:
+              title: CloudEvent Source
+              description: The event source. By default, the DDB Stream Event source receipt handle with prefix "aws.ddbstream.".
+              type: string
+            CamelCloudEventSubject:
+              title: CloudEvent Subject
+              description: The event subject. The DDB Stream Event Id.
+              type: string
+            CamelCloudEventTime:
+              title: CloudEvent Time
+              description: The exchange creation timestamp as event time.
+              type: string
   dependencies:
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:2.3.0
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
@@ -115,7 +157,6 @@ spec:
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
       steps:
-      - marshal:
-          json:
-            library: Gson
+      - transform:
+          toType: "aws2-ddb:application-x-struct"
       - to: "kamelet:sink"

--- a/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
+++ b/library/camel-kamelets-catalog/src/main/resources/kamelets/aws-ddb-streams-source.kamelet.yaml
@@ -69,7 +69,7 @@ spec:
         enum: ["ap-south-1", "eu-south-1", "us-gov-east-1", "me-central-1", "ca-central-1", "eu-central-1", "us-iso-west-1", "us-west-1", "us-west-2", "af-south-1", "eu-north-1", "eu-west-3", "eu-west-2", "eu-west-1", "ap-northeast-3", "ap-northeast-2", "ap-northeast-1", "me-south-1", "sa-east-1", "ap-east-1", "cn-north-1", "us-gov-west-1", "ap-southeast-1", "ap-southeast-2", "us-iso-east-1", "ap-southeast-3", "us-east-1", "us-east-2", "cn-northwest-1", "us-isob-east-1", "aws-global", "aws-cn-global", "aws-us-gov-global", "aws-iso-global", "aws-iso-b-global"]
       streamIteratorType:
         title: Stream Iterator Type
-        description: Defines where in the DynamoDB stream to start getting records. There are two enums and the value can be one of FROM_LATEST and FROM_START. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time. 
+        description: Defines where in the DynamoDB stream to start getting records. There are two enums and the value can be one of FROM_LATEST and FROM_START. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time.
         type: string
         default: FROM_LATEST
       useDefaultCredentialsProvider:
@@ -95,10 +95,52 @@ spec:
         description: The number of milliseconds before the next poll from the database.
         type: integer
         default: 500
-  types:
+  dataTypes:
     out:
-      mediaType: application/json
+      default: json
+      headers:
+        CamelAwsDdbStreamEventSource:
+          title: The DDB Stream Event Source
+          description: The Amazon Web Services service from which the stream record originated. For DynamoDB Streams, this is aws:dynamodb.
+          type: string
+        CamelAwsDdbStreamEventId:
+          title: The DDB Stream Event Id
+          description: A globally unique identifier for the event that was recorded in this stream record.
+          type: string
+      types:
+        json:
+          format: "application-json"
+          description: Default Json representation of a DDB Stream Event.
+          mediaType: application/json
+        cloudevents:
+          format: "aws2-ddbstream:application-cloudevents"
+          description: |-
+            Data type transformer converts AWS Dynamo DB Streams get records response to CloudEvent v1_0 data format. The data
+            type sets Camel specific CloudEvent headers with values extracted from AWS Dynamo DB Streams get records.
+          headers:
+            CamelCloudEventID:
+              title: CloudEvent ID
+              description: The Camel exchange id set as event id
+              type: string
+            CamelCloudEventType:
+              title: CloudEvent Type
+              description: The event type
+              default: "org.apache.camel.event.aws.ddbstream.getRecords"
+              type: string
+            CamelCloudEventSource:
+              title: CloudEvent Source
+              description: The event source. By default, the DDB Stream Event source receipt handle with prefix "aws.ddbstream.".
+              type: string
+            CamelCloudEventSubject:
+              title: CloudEvent Subject
+              description: The event subject. The DDB Stream Event Id.
+              type: string
+            CamelCloudEventTime:
+              title: CloudEvent Time
+              description: The exchange creation timestamp as event time.
+              type: string
   dependencies:
+  - mvn:org.apache.camel.kamelets:camel-kamelets-utils:2.3.0
   - "camel:gson"
   - "camel:aws2-ddb"
   - "camel:kamelet"
@@ -115,7 +157,6 @@ spec:
         overrideEndpoint: "{{overrideEndpoint}}"
         delay: "{{delay}}"
       steps:
-      - marshal:
-          json:
-            library: Gson
+      - transform:
+          toType: "aws2-ddb:application-x-struct"
       - to: "kamelet:sink"

--- a/library/camel-kamelets-utils/pom.xml
+++ b/library/camel-kamelets-utils/pom.xml
@@ -86,6 +86,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Dependencies for Gson serialization type adapter -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-gson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scoped dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/serialization/gson/JavaTimeInstantTypeAdapter.java
+++ b/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/serialization/gson/JavaTimeInstantTypeAdapter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kamelets.utils.serialization.gson;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class JavaTimeInstantTypeAdapter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+
+    @Override
+    public JsonElement serialize(final Instant time, final Type typeOfSrc,
+                                 final JsonSerializationContext context) {
+        return new JsonPrimitive(time.getEpochSecond() * 1000);
+    }
+
+    @Override
+    public Instant deserialize(final JsonElement json, final Type typeOfT,
+                                 final JsonDeserializationContext context) throws JsonParseException {
+        return Instant.ofEpochMilli(json.getAsLong());
+    }
+}

--- a/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/transform/aws2/ddb/Ddb2JsonStructDataTypeTransformer.java
+++ b/library/camel-kamelets-utils/src/main/java/org/apache/camel/kamelets/utils/transform/aws2/ddb/Ddb2JsonStructDataTypeTransformer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.camel.kamelets.utils.transform.aws2.ddb;
+
+import java.time.Instant;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.camel.Message;
+import org.apache.camel.kamelets.utils.serialization.gson.JavaTimeInstantTypeAdapter;
+import org.apache.camel.spi.DataType;
+import org.apache.camel.spi.DataTypeTransformer;
+import org.apache.camel.spi.Transformer;
+
+@DataTypeTransformer(name = "aws2-ddb:application-x-struct")
+public class Ddb2JsonStructDataTypeTransformer extends Transformer {
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Instant.class, new JavaTimeInstantTypeAdapter())
+            .create();
+
+    @Override
+    public void transform(Message message, DataType fromType, DataType toType) {
+        if (message.getBody() instanceof String) {
+            return;
+        }
+
+        message.setBody(gson.toJson(message.getBody()));
+    }
+}

--- a/library/camel-kamelets-utils/src/main/resources/META-INF/services/org/apache/camel/transformer/aws2-ddb-application-x-struct
+++ b/library/camel-kamelets-utils/src/main/resources/META-INF/services/org/apache/camel/transformer/aws2-ddb-application-x-struct
@@ -1,0 +1,1 @@
+class=org.apache.camel.kamelets.utils.transform.aws2.ddb.Ddb2JsonStructDataTypeTransformer

--- a/library/camel-kamelets-utils/src/main/resources/META-INF/services/org/apache/camel/transformer/aws2-ddb-application-x-struct.json
+++ b/library/camel-kamelets-utils/src/main/resources/META-INF/services/org/apache/camel/transformer/aws2-ddb-application-x-struct.json
@@ -1,0 +1,13 @@
+{
+  "transformer": {
+    "kind": "transformer",
+    "name": "aws2-ddb:application-x-struct",
+    "title": "Aws2 Ddb (Application Json Struct)",
+    "description": "Transforms DynamoDB record into a Json node",
+    "deprecated": false,
+    "javaType": "org.apache.camel.kamelets.utils.transform.aws2.ddb.Ddb2JsonStructDataTypeTransformer",
+    "groupId": "org.apache.camel",
+    "artifactId": "camel-aws2-ddb",
+    "version": "4.6.0-SNAPSHOT"
+  }
+}


### PR DESCRIPTION
- Use specific data type transformation to marshal the aws2-ddb record domain model to Json
- Arbitrary Gson marshalling is not able to handle Java time instant type that is being used in aws2-ddb domain model
- Add Java time instant Gson type adapter
- Use Gson with timer instant type adapter in aws2-ddb Json Struct data type transformer