### PR TITLE
Fix salesforce-update-sink.kamelet

### DIFF
--- a/salesforce-update-sink.kamelet.yaml
+++ b/salesforce-update-sink.kamelet.yaml
@@ -87,14 +87,21 @@ spec:
     from:
       uri: kamelet:source
       steps:
-        - set-property:
+        - setHeader:
             name: sObjectId
-            jsonpath: "$['sObjectId']"
-        - set-property:
+            jsonpath: "$.sObjectId"
+        - setHeader:
             name: sObjectName
-            jsonpath: "$['sObjectName']"
+            jsonpath: "$.sObjectName"
         - transform:
-            jsonpath: "$['payload']"
+            jsonpath: "$.payload"
         - marshal:
             json: {}
-        - toD: "{{local-salesforce}}:updateSObject?sObjectId=${exchangeProperty.sObjectId}&sObjectName=${exchangeProperty.sObjectName}&rawPayload=true"
+        - to:
+            uri: "{{local-salesforce}}:updateSObject"
+            parameters:
+              rawPayload: "true"
+        - removeHeader:
+            name: sObjectId
+        - removeHeader:
+            name: sObjectName


### PR DESCRIPTION
At runtime the bean is renamed which seems to cause the NoSuchEndpointException: No endpoint could be found for: local-salesforce-1

CMLK-2211 Kamelet salesforce-update-sink throws NoSuchEndpointException